### PR TITLE
add go.mod, go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/rd101/dotori
+
+go 1.12
+
+require (
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rd101/dotori
 
-go 1.12
+go 1.13
 
 require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=


### PR DESCRIPTION
Go 1.13 부터는 Gopath 없이 go.mod go.sum을 사용한다.

사실 Go를 사용하면서 별도의 설저잉 필요없어야 한다.