### PR TITLE
rm REST API 작성

### DIFF
--- a/http.go
+++ b/http.go
@@ -32,7 +32,7 @@ func webserver() {
 	http.HandleFunc("/add", handleAdd)
 	http.HandleFunc("/search", handleSearch)
 	// REST API
-	http.HandleFunc("/api/item", handleAPIAdd)
+	http.HandleFunc("/api/item", handleAPIItem)
 	// 웹서버 실행
 	err = http.ListenAndServe(*flagHTTPPort, nil)
 	if err != nil {

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"gopkg.in/mgo.v2"
@@ -74,23 +73,16 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(data)
 	} else if r.Method == http.MethodDelete {
-		var itemtype, id string
-		r.ParseForm()
-		for key, values := range r.Form {
-			switch key {
-			case "type":
-				if len(values) != 1 {
-					http.Error(w, "type을 설정해 주세요", http.StatusBadRequest)
-					return
-				}
-				itemtype = values[0]
-			case "id":
-				if len(values) != 1 {
-					http.Error(w, "id를 설정해 주세요", http.StatusBadRequest)
-					return
-				}
-				id = values[0]
-			}
+		q := r.URL.Query()
+		itemtype := q.Get("type")
+		id := q.Get("id")
+		if itemtype == "" {
+			http.Error(w, "URL에 itemtype을 입력해주세요", http.StatusBadRequest)
+			return
+		}
+		if id == "" {
+			http.Error(w, "URL에 id를 입력해주세요", http.StatusBadRequest)
+			return
 		}
 		session, err := mgo.Dial(*flagDBIP)
 		if err != nil {
@@ -98,8 +90,6 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer session.Close()
-		fmt.Printf("itemtype  %T  %s\n", itemtype, itemtype)
-		fmt.Printf("id  %T  %s\n", id, id)
 		RmItem(session, itemtype, id)
 		data, _ := json.Marshal(id)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -2,78 +2,112 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"gopkg.in/mgo.v2"
 )
 
-func handleAPIAdd(w http.ResponseWriter, r *http.Request) {
-	//POST method만 받겠다
-	if r.Method != http.MethodPost {
-		http.Error(w, "Post Only", http.StatusMethodNotAllowed)
-		return
-	}
-	i := Item{}
-	//ParseForm parses the raw query from the URL and updates r.Form.
-	r.ParseForm()
-	for key, values := range r.PostForm {
-		switch key {
-		case "type":
-			if len(values) != 1 {
-				http.Error(w, "type을 설정해 주세요", http.StatusBadRequest)
-				return
+func handleAPIItem(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		i := Item{}
+		//ParseForm parses the raw query from the URL and updates r.Form.
+		r.ParseForm()
+		for key, values := range r.PostForm {
+			switch key {
+			case "type":
+				if len(values) != 1 {
+					http.Error(w, "type을 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Type = values[0]
+			case "author":
+				if len(values) != 1 {
+					http.Error(w, "author를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Author = values[0]
+			case "inputpath":
+				if len(values) != 1 {
+					http.Error(w, "inputpath를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Inputpath = values[0]
+			case "outputpath":
+				if len(values) != 1 {
+					http.Error(w, "outputpath를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Outputpath = values[0]
+			case "thumbimg":
+				if len(values) != 1 {
+					http.Error(w, "thumbnail image의 경로를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Thumbimg = values[0]
+			case "thumbmov":
+				if len(values) != 1 {
+					http.Error(w, "thumbnail mov의 경로를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				i.Thumbmov = values[0]
 			}
-			i.Type = values[0]
-		case "author":
-			if len(values) != 1 {
-				http.Error(w, "author를 설정해 주세요", http.StatusBadRequest)
-				return
-			}
-			i.Author = values[0]
-		case "inputpath":
-			if len(values) != 1 {
-				http.Error(w, "inputpath를 설정해 주세요", http.StatusBadRequest)
-				return
-			}
-			i.Inputpath = values[0]
-		case "outputpath":
-			if len(values) != 1 {
-				http.Error(w, "outputpath를 설정해 주세요", http.StatusBadRequest)
-				return
-			}
-			i.Outputpath = values[0]
-		case "thumbimg":
-			if len(values) != 1 {
-				http.Error(w, "thumbnail image의 경로를 설정해 주세요", http.StatusBadRequest)
-				return
-			}
-			i.Thumbimg = values[0]
-		case "thumbmov":
-			if len(values) != 1 {
-				http.Error(w, "thumbnail mov의 경로를 설정해 주세요", http.StatusBadRequest)
-				return
-			}
-			i.Thumbmov = values[0]
 		}
-	}
-	err := i.CheckError()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		err := i.CheckError()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		session, err := mgo.Dial(*flagDBIP)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer session.Close()
+		err = AddItem(session, i)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, _ := json.Marshal(i)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	} else if r.Method == http.MethodDelete {
+		var itemtype, id string
+		r.ParseForm()
+		for key, values := range r.Form {
+			switch key {
+			case "type":
+				if len(values) != 1 {
+					http.Error(w, "type을 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				itemtype = values[0]
+			case "id":
+				if len(values) != 1 {
+					http.Error(w, "id를 설정해 주세요", http.StatusBadRequest)
+					return
+				}
+				id = values[0]
+			}
+		}
+		session, err := mgo.Dial(*flagDBIP)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer session.Close()
+		fmt.Printf("itemtype  %T  %s\n", itemtype, itemtype)
+		fmt.Printf("id  %T  %s\n", id, id)
+		RmItem(session, itemtype, id)
+		data, _ := json.Marshal(id)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	} else {
+		http.Error(w, "Not Supported Method", http.StatusMethodNotAllowed)
 		return
 	}
-	session, err := mgo.Dial(*flagDBIP)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer session.Close()
-	err = AddItem(session, i)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	data, _ := json.Marshal(i)
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+
 }

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -90,8 +90,16 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer session.Close()
-		RmItem(session, itemtype, id)
-		data, _ := json.Marshal(id)
+		err = RmItem(session, itemtype, id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, err := json.Marshal(id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		w.Write(data)

--- a/testdata.sh
+++ b/testdata.sh
@@ -6,3 +6,5 @@ dotori -add -author liah -type houdini -inputpath /library/asset -outputpath /li
 
 #REST API
 curl -X POST -d "author=bae&type=nuke&inputpath=/library/asset&outputpath=/library/asset&thumbimg=/library/asset&thumbmov=/library/asset" http://127.0.0.1/api/item
+#DELETE는 실행 전에 직접 id를 넣어준 후 테스트한다.
+#curl -X DELETE -d "type=nuke&id=" http://127.0.0.1/api/item

--- a/testdata.sh
+++ b/testdata.sh
@@ -7,4 +7,4 @@ dotori -add -author liah -type houdini -inputpath /library/asset -outputpath /li
 #REST API
 curl -X POST -d "author=bae&type=nuke&inputpath=/library/asset&outputpath=/library/asset&thumbimg=/library/asset&thumbmov=/library/asset" http://127.0.0.1/api/item
 #DELETE는 실행 전에 직접 id를 넣어준 후 테스트한다.
-#curl -X DELETE -d "type=nuke&id=" http://127.0.0.1/api/item
+#curl -X DELETE "http://127.0.0.1/api/item?type=nuke&id="


### PR DESCRIPTION
- item을 삭제하는 API 작성
  - DELETE메소드의 경우 서버가 body를 읽지 않기 때문에, POST의 경우처럼 body를 통해 데이터를 전달할 수 없음
  - 그래서 url을 통해 type과 id를 받아서 해당 아이템을 삭제함.
  - curl을 쓸 때 url뒤에 `&`가 붙으면 다른 명령어(백그라운드로 실행)인식하기 때문에 url을 `""`로 묶어줌.
- API의 구조를 RESTful하게 변경
```
  if 메소드 == POST{
  }
  else if 메소드 == DELETE{
  }
 else {
    "지원하지 않는 메소드입니다"
  }
```