### PR TITLE
itemtype이 공백인지 체크

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -63,6 +63,9 @@ func (i Item) CheckError() error {
 	i.CreateTime = "2019-09-09T14:43:34+09:00"
 	i.Updatetime = "2019-09-09T14:43:34+09:00"
 
+	if i.ItemType == "" {
+		return errors.New("itemtype을 입력해주세요")
+	}
 	if !regexRFC3339Time.MatchString(i.CreateTime) {
 		return errors.New("생성시간이 2019-09-09T14:43:34+09:00 형식의 문자열이 아닙니다")
 	}


### PR DESCRIPTION
close: #268 
item이었을 때 추가한 데이터에서만 버그가 생기는 것을 보아
struct의 item을 itemtype으로 바꾸면서 생긴 버그 같음.

- DB의 기존 데이터를 지우고 새로 넣음
- checkError함수에 itemtype이 입력이 안된 경우 error처리하는 구문 추가
