### PR TITLE
DB에 바로 저장하는 상황에 맞게 자료구조 정리

### DIFF
--- a/dotori.go
+++ b/dotori.go
@@ -27,9 +27,7 @@ var (
 	flagTag         = flag.String("tag", "", "tag")
 	flagDescription = flag.String("description", "", "description")
 	flagThumbimg    = flag.String("thumbimg", "", "path of thumbnail image")
-	flagThumbmov    = flag.String("thumbmov", "", "path of thumbnail mov")
 	flagInputpath   = flag.String("inputpath", "", "input path")
-	flagOutputpath  = flag.String("outputpath", "", "output path")
 	flagItemType    = flag.String("itemtype", "", "type of asset")
 	flagAttributes  = flag.String("attributes", "", "detail info of file") // "key:value,key:value"
 
@@ -74,9 +72,6 @@ func main() {
 		i.Tags = SplitBySpace(*flagTag)
 		i.Description = *flagDescription
 		i.Thumbimg = *flagThumbimg
-		i.Thumbmov = *flagThumbmov
-		i.Inputpath = *flagInputpath
-		i.Outputpath = *flagOutputpath
 		i.ItemType = *flagItemType
 		i.Attributes = StringToMap(*flagAttributes)
 

--- a/dotori.go
+++ b/dotori.go
@@ -28,6 +28,7 @@ var (
 	flagDescription = flag.String("description", "", "description")
 	flagThumbimg    = flag.String("thumbimg", "", "path of thumbnail image")
 	flagInputpath   = flag.String("inputpath", "", "input path")
+	flagOutputpath  = flag.String("outputpath", "", "outout path")
 	flagItemType    = flag.String("itemtype", "", "type of asset")
 	flagAttributes  = flag.String("attributes", "", "detail info of file") // "key:value,key:value"
 
@@ -72,6 +73,7 @@ func main() {
 		i.Tags = SplitBySpace(*flagTag)
 		i.Description = *flagDescription
 		i.Thumbimg = *flagThumbimg
+		i.Outputpath = *flagOutputpath
 		i.ItemType = *flagItemType
 		i.Attributes = StringToMap(*flagAttributes)
 

--- a/dotori.go
+++ b/dotori.go
@@ -28,7 +28,7 @@ var (
 	flagDescription = flag.String("description", "", "description")
 	flagThumbimg    = flag.String("thumbimg", "", "path of thumbnail image")
 	flagInputpath   = flag.String("inputpath", "", "input path")
-	flagOutputpath  = flag.String("outputpath", "", "outout path")
+	flagOutputpath  = flag.String("outputpath", "", "output path")
 	flagItemType    = flag.String("itemtype", "", "type of asset")
 	flagAttributes  = flag.String("attributes", "", "detail info of file") // "key:value,key:value"
 

--- a/http_add.go
+++ b/http_add.go
@@ -205,15 +205,16 @@ func handleUploadMayaOnDB(w http.ResponseWriter, r *http.Request) {
 		attr[key] = value
 	}
 	item.Attributes = attr
-	item.Thumbimg = "/tmp/dotori/thumbnail"
-	item.Thumbmov = "/tmp/dotori/preview"
-	item.Inputpath = "/tmp/dotori"
-	outputpath, err := idToPath(item.ID.Hex())
+	objIDpath, err := idToPath(item.ID.Hex())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	item.Outputpath = outputpath + "/dotori"
+	item.Thumbimg = objIDpath
+	item.ThumbMedia.Ogg = objIDpath
+	item.ThumbMedia.Mp4 = objIDpath
+	item.ThumbMedia.Mov = objIDpath
+	item.Outputpath = objIDpath
 	item.Status = Ready
 	time := time.Now()
 	item.CreateTime = time.Format("2006-01-02 15:04:05")

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -26,12 +26,6 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				i.Author = values[0]
-			case "inputpath":
-				if len(values) != 1 {
-					http.Error(w, "inputpath를 설정해 주세요", http.StatusBadRequest)
-					return
-				}
-				i.Inputpath = values[0]
 			case "outputpath":
 				if len(values) != 1 {
 					http.Error(w, "outputpath를 설정해 주세요", http.StatusBadRequest)
@@ -44,12 +38,6 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				i.Thumbimg = values[0]
-			case "thumbmov":
-				if len(values) != 1 {
-					http.Error(w, "thumbnail mov의 경로를 설정해 주세요", http.StatusBadRequest)
-					return
-				}
-				i.Thumbmov = values[0]
 			}
 		}
 		err := i.CheckError()

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,14 +20,7 @@ func processingItem() error {
 	if err != nil {
 		return err
 	}
-	// Status : 복사중
-	item.Status = Copying
-	src := item.Inputpath
-	dst := item.Outputpath
-	err = copyDir(src, dst)
-	if err != nil {
-		return err
-	}
+	fmt.Println(item)
 	return nil
 }
 

--- a/struct.go
+++ b/struct.go
@@ -32,23 +32,30 @@ type User struct {
 	AccessLevel string `json:"accesslevel" bson:"accesslevel"` // admin, manager, user
 }
 
+// ThumbMedia 는 썸네일 영상에 쓰이는 파일 포맷 자료구조이다.
+type ThumbMedia struct {
+	Ogg string `json:"ogg" bson:"ogg"`
+	Mp4 string `json:"mp4" bson:"mp4"`
+	Mov string `json:"mov" bson:"mov"`
+}
+
 // Item 은 라이브러리의 에셋 자료구조이다.
 type Item struct {
-	ID          bson.ObjectId     `json:"id" bson:"_id,omitempty"`        // ID
-	Author      string            `json:"author" bson:"author"`           // 에셋을 제작한 사람
-	Tags        []string          `json:"tags" bson:"tags"`               // 태그리스트
-	Description string            `json:"description" bson:"description"` // 에셋에 대한 추가 정보. 에셋의 제약, 사용전 알아야 할 특징
-	Thumbimg    string            `json:"thumbimg" bson:"thumbimg"`       // 썸네일 이미지 주소
-	Thumbmov    string            `json:"thumbmov" bson:"thumbmov"`       // 썸네일 영상 주소
-	Inputpath   string            `json:"inputpath" bson:"inputpath"`     // 최초 등록되는 경로
-	Outputpath  string            `json:"outputpath" bson:"outputpath"`   // 저장되는 경로
-	ItemType    string            `json:"itemtype" bson:"itemtype"`       // maya, source, houdini, blender, nuke ..  같은 형태인가.
-	Status      ItemStatus        `json:"status" bson:"status"`           // 상태(에러, done, wip)
-	Log         string            `json:"log" bson:"log"`                 // 데이터를 처리할 때 생성되는 로그
-	CreateTime  string            `json:"createtime" bson:"createtime"`   // Item 생성 시간
-	Updatetime  string            `json:"updatetime" bson:"updatetime"`   // UTC 타임으로 들어가도록 하기.
-	UsingRate   int64             `json:"usingrate" bson:"usingrate"`     // 사용 빈도 수
-	Attributes  map[string]string `json:"attributes" bson:"attributes"`   // 해상도, 속성, 메타데이터 등의 파일정보
+	ID          bson.ObjectId `json:"id" bson:"_id,omitempty"`        // ID
+	Author      string        `json:"author" bson:"author"`           // 에셋을 제작한 사람
+	Tags        []string      `json:"tags" bson:"tags"`               // 태그리스트
+	Description string        `json:"description" bson:"description"` // 에셋에 대한 추가 정보. 에셋의 제약, 사용전 알아야 할 특징
+	Thumbimg    string        `json:"thumbimg" bson:"thumbimg"`       // 썸네일 이미지 주소
+
+	Outputpath string                                `json:"outputpath" bson:"outputpath"` // 저장되는 경로
+	ItemType   string                                `json:"itemtype" bson:"itemtype"`     // maya, source, houdini, blender, nuke ..  같은 형태인가.
+	Status     ItemStatus                            `json:"status" bson:"status"`         // 상태(에러, done, wip)
+	Log        string                                `json:"log" bson:"log"`               // 데이터를 처리할 때 생성되는 로그
+	CreateTime string                                `json:"createtime" bson:"createtime"` // Item 생성 시간
+	Updatetime string                                `json:"updatetime" bson:"updatetime"` // UTC 타임으로 들어가도록 하기.
+	UsingRate  int64                                 `json:"usingrate" bson:"usingrate"`   // 사용 빈도 수
+	Attributes map[string]string                     `json:"attributes" bson:"attributes"` // 해상도, 속성, 메타데이터 등의 파일정보
+	ThumbMedia `json:"thumbmedia" bson:"thumbmedia"` // .mp4, .mov, .ogg 같은 데이터를 담을 때 사용한다.
 }
 
 // ItemStatus 는 숫자이다.
@@ -80,9 +87,6 @@ func (i Item) CheckError() error {
 	}
 	if !regexRFC3339Time.MatchString(i.Updatetime) {
 		return errors.New("업데이트 시간이 2019-09-09T14:43:34+09:00 형식의 문자열이 아닙니다")
-	}
-	if !regexPath.MatchString(i.Inputpath) {
-		return errors.New("최초 등록 경로가 /test/test 형식의 문자열이 아닙니다")
 	}
 	if !regexPath.MatchString(i.Outputpath) {
 		return errors.New("asset 저장 경로가 /test/test 형식의 문자열이 아닙니다")

--- a/testdata.sh
+++ b/testdata.sh
@@ -1,24 +1,24 @@
 #!/bin/sh
 #DB에 아이템 추가 테스트를 위한 명령어를 모아둔 파일
-dotori -add -author bae -itemtype nuke -inputpath /library/asset -outputpath /library/asset
-dotori -add -author liah -itemtype houdini -inputpath /library/asset -outputpath /library/asset
-dotori -add -author woong -itemtype maya -inputpath /library/asset/01 -outputpath /library/asset -description "description1 about some details" -tag "나무 낙엽 item1"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/02 -outputpath /library/asset -description "description2 about some details" -tag "나무 낙엽 item2"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/03 -outputpath /library/asset -description "description3 about some details" -tag "나무 낙엽 item3"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/04 -outputpath /library/asset -description "description4 about some details" -tag "나무 낙엽 item4"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/05 -outputpath /library/asset -description "description5 about some details" -tag "나무 낙엽 item5"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/06 -outputpath /library/asset -description "description6 about some details" -tag "나무 낙엽 item6"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/07 -outputpath /library/asset -description "description7 about some details" -tag "나무 낙엽 item7"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/08 -outputpath /library/asset -description "description8 about some details" -tag "나무 낙엽 item8"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/09 -outputpath /library/asset -description "description9 about some details" -tag "나무 낙엽 item9"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/10 -outputpath /library/asset -description "description10 about some details" -tag "나무 낙엽 item10"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/11 -outputpath /library/asset -description "description11 about some details" -tag "나무 낙엽 item11"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/12 -outputpath /library/asset -description "description12 about some details" -tag "나무 낙엽 item12"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/13 -outputpath /library/asset -description "description13 about some details" -tag "나무 낙엽 item13"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/14 -outputpath /library/asset -description "description14 about some details" -tag "나무 낙엽 item14"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/15 -outputpath /library/asset -description "description15 about some details" -tag "나무 낙엽 item15"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/16 -outputpath /library/asset -description "description16 about some details" -tag "나무 낙엽 item16"
-dotori -add -author woong -itemtype maya -inputpath /library/asset/17 -outputpath /library/asset -description "description17 about some details" -tag "나무 낙엽 item17"
+dotori -add -author bae -itemtype nuke -outputpath /library/asset
+dotori -add -author liah -itemtype houdini -outputpath /library/asset
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description1 about some details" -tag "나무 낙엽 item1"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description2 about some details" -tag "나무 낙엽 item2"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description3 about some details" -tag "나무 낙엽 item3"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description4 about some details" -tag "나무 낙엽 item4"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description5 about some details" -tag "나무 낙엽 item5"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description6 about some details" -tag "나무 낙엽 item6"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description7 about some details" -tag "나무 낙엽 item7"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description8 about some details" -tag "나무 낙엽 item8"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description9 about some details" -tag "나무 낙엽 item9"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description10 about some details" -tag "나무 낙엽 item10"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description11 about some details" -tag "나무 낙엽 item11"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description12 about some details" -tag "나무 낙엽 item12"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description13 about some details" -tag "나무 낙엽 item13"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description14 about some details" -tag "나무 낙엽 item14"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description15 about some details" -tag "나무 낙엽 item15"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description16 about some details" -tag "나무 낙엽 item16"
+dotori -add -author woong -itemtype maya -outputpath /library/asset -description "description17 about some details" -tag "나무 낙엽 item17"
 
 #REST API
 curl -X POST -d "author=bae&itemtype=nuke&inputpath=/library/asset&outputpath=/library/asset&thumbimg=/library/asset&thumbmov=/library/asset" http://127.0.0.1/api/item


### PR DESCRIPTION
- 자료구조에서 Inputpath 삭제
    - tmp에 저장했다가 DB로 옮기는 구조가 아니어서 더이상 Inputpath가 필요없다.
    - Inputpath를 레귤러 익스프레션으로 체크하는 부분 삭제
    - testdata에서 inputpath 부분 삭제
- ThumbMedia 자료구조 추가
    - 프리뷰는 여러 개의 포맷으로 뽑을 것이기 때문에 추가.
- process.go에서 tmp에서 DB로 복사하는 과정 삭제
