### PR TITLE
아이템 Status를 수정한 후에 결과를 반환하도록 GetReadyItem함수 리팩토링

### DIFF
--- a/dbapi.go
+++ b/dbapi.go
@@ -247,7 +247,11 @@ func GetReadyItem(session *mgo.Session) (Item, error) {
 	if err != nil {
 		return result, err
 	}
+	// 컬렉션을 for문 돌면서 Ready 상태인 Item을 찾는다.
 	for _, c := range collections {
+		if c == "setting.admin" { // setting.admin 컬렉션은 제외한다.
+			continue
+		}
 		// 해당 컬렉션에 ready상태인 Item이 없으면 다음 컬렉션을 체크한다
 		num, err := session.DB(*flagDBName).C(c).Find(bson.M{"status": Ready}).Count()
 		if err != nil {
@@ -256,11 +260,17 @@ func GetReadyItem(session *mgo.Session) (Item, error) {
 		if num == 0 {
 			continue
 		}
-		// ready상태인 Item이 있으면 하나를 반환하고 끝낸다.
+		// ready상태인 Item이 있다면 가져와서 Status를 업데이트 한다.
 		err = session.DB(*flagDBName).C(c).Find(bson.M{"status": Ready}).One(&result)
 		if err != nil {
 			return result, err
 		}
+		result.Status = StartProcessing
+		err = session.DB(*flagDBName).C(c).Update(bson.M{"_id": result.ID}, result)
+		if err != nil {
+			return result, err
+		}
+		// 해당 Item을 반환한다.
 		return result, nil
 	}
 	return result, errors.New("ready상태인 Item이 없습니다")

--- a/dbapi.go
+++ b/dbapi.go
@@ -252,6 +252,9 @@ func GetReadyItem(session *mgo.Session) (Item, error) {
 		if c == "setting.admin" { // setting.admin 컬렉션은 제외한다.
 			continue
 		}
+		if c == "system.indexs" { //mongodb의 기본 컬렉션. 제외한다.
+			continue
+		}
 		cur := session.DB(*flagDBName).C(c)
 		// 해당 컬렉션에 ready상태인 Item이 없으면 다음 컬렉션을 체크한다
 		num, err := cur.Find(bson.M{"status": Ready}).Count()

--- a/process.go
+++ b/process.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
 
 	"gopkg.in/mgo.v2"
 )
@@ -15,63 +12,11 @@ func processingItem() error {
 		return err
 	}
 	defer session.Close()
-
+	// Status가 Ready인 item을 가져온다.
 	item, err := GetReadyItem(session)
 	if err != nil {
 		return err
 	}
 	fmt.Println(item)
-	return nil
-}
-
-func copyDir(src, dst string) (err error) {
-	// 목적지 폴더를 만든다.
-	err = os.MkdirAll(dst, 0777)
-	if err != nil {
-		return err
-	}
-	// 소스 폴더 하위의 파일 목록을 가져온다.
-	files, err := ioutil.ReadDir(src)
-	if err != nil {
-		return err
-	}
-	// 파일 리스트를 for문 돌면서 하나씩 복사한다.
-	for _, f := range files {
-		if f.IsDir() { // 디렉토리라면 복사하지 않는다.
-			continue
-		}
-		s := src + "/" + f.Name()
-		d := dst + "/" + f.Name()
-		err = copyFile(s, d)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func copyFile(src, dst string) (err error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		cerr := out.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-	if _, err = io.Copy(out, in); err != nil {
-		return err
-	}
-	err = out.Sync()
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/struct.go
+++ b/struct.go
@@ -72,14 +72,13 @@ type ItemStatus int
 
 // item의 상태
 const (
-	Ready             = ItemStatus(iota) // 0 복사전
-	Copying                              // 1 복사중
-	Copied                               // 2 복사 완료
-	CreatingThumbnail                    // 3 썸네일 생성중
-	CreatedThumbnail                     // 4 썸네일 생성완료
-	CreatingContainer                    // 5 썸네일 동영상 생성중
-	CreatedContainer                     // 6 썸네일 동영상 생성완료
-	Done                                 // 7 등록 완료
+	Ready             = ItemStatus(iota) // 복사전
+	StartProcessing                      // 처리 시작
+	CreatingThumbnail                    // 썸네일 생성중
+	CreatedThumbnail                     // 썸네일 생성완료
+	CreatingContainer                    // 썸네일 동영상 생성중
+	CreatedContainer                     // 썸네일 동영상 생성완료
+	Done                                 // 등록 완료
 )
 
 // CheckError 는 Item 자료구조에 값이 정확히 들어갔는지 확인하는 메소드이다.


### PR DESCRIPTION
close: #291 
<img width="433" alt="image" src="https://user-images.githubusercontent.com/40417084/76775792-3dcb5c80-67e9-11ea-9836-73176241fe79.png">

- Monotonic모드이기 때문에 함수전체가 하나의 트렌젝션 단위가 된다.
- 그래서 트렌젝션을 따로 추가하지는 않고 위 플로우차트에 따라 Status를 수정하는 명령어 추가
- setting.admin 컬렉션은 검사하지 않도록 함.
- 사용하지 않는 함수 삭제(copyDir, copyFile)
- DB로 복사하는 과정이 없어졌기 때문에 이에 맞게 ItemStatus 수정