### PR TITLE
add maya와 관련된 url, 함수이름 수정

### DIFF
--- a/assets/template/addmaya-file.html
+++ b/assets/template/addmaya-file.html
@@ -1,4 +1,4 @@
-{{define "addmaya"}}
+{{define "addmaya-file"}}
 {{template "head"}}
 <body>
 {{template "navbar"}}
@@ -9,7 +9,7 @@
             <h2 class="text-muted">Add Maya Asset</h2>
         </div>
         <div class="">
-            <form action="/upload-maya" method="post" class="dropzone" enctype="multipart/form-data">
+            <form action="/uploadmaya-file" method="post" class="dropzone" enctype="multipart/form-data">
                 <div class="fallback">
                     <input name="file" type="file" />
                 </div>

--- a/assets/template/addmaya-item.html
+++ b/assets/template/addmaya-item.html
@@ -2,7 +2,7 @@
 {{template "head"}}
 <body>
 {{template "navbar"}}
-<form action="/upload-maya-ondb" method="post">
+<form action="/uploadmaya-item" method="post">
 <div class="container py-5 px-2">
     <div class="col-lg-6 col-md-8 col-sm-12 mx-auto">
         <div class="pt-3 pb-3">

--- a/http.go
+++ b/http.go
@@ -41,11 +41,11 @@ func webserver() {
 	http.HandleFunc("/search-submit", handleSearchSubmit)
 
 	// Maya
-	http.HandleFunc("/addmaya", handleAddMaya)
-	http.HandleFunc("/addmaya-item", handleAddMayaItem)
 	http.HandleFunc("/addmaya-submit", handleAddMayaSubmit)
-	http.HandleFunc("/upload-maya", handleUploadMaya)
-	http.HandleFunc("/upload-maya-ondb", handleUploadMayaOnDB)
+	http.HandleFunc("/addmaya-item", handleAddMayaItem)
+	http.HandleFunc("/addmaya-file", handleAddMayaFile)
+	http.HandleFunc("/uploadmaya-item", handleUploadMayaItem)
+	http.HandleFunc("/uploadmaya-file", handleUploadMayaFile)
 	http.HandleFunc("/addmaya-success", handleAddMayaSuccess)
 	http.HandleFunc("/editmaya", handleEditMaya)
 	http.HandleFunc("/editmaya-submit", handleEditMayaSubmit)

--- a/http_add.go
+++ b/http_add.go
@@ -15,10 +15,10 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// handleAddMaya 함수는 Maya 파일을 추가하는 페이지 이다.
-func handleAddMaya(w http.ResponseWriter, r *http.Request) {
+// handleAddMayaFile 함수는 Maya 파일을 추가하는 페이지 이다.
+func handleAddMayaFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
-	err := TEMPLATES.ExecuteTemplate(w, "addmaya", nil)
+	err := TEMPLATES.ExecuteTemplate(w, "addmaya-file", nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -34,7 +34,7 @@ func handleAddMayaItem(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleAddMayaSubmit 함수는 URL에 objectID를 붙여서 /addmaya 페이지로 redirect한다.
+// handleAddMayaSubmit 함수는 URL에 objectID를 붙여서 /addmaya-item 페이지로 redirect한다.
 func handleAddMayaSubmit(w http.ResponseWriter, r *http.Request) {
 	objectID := bson.NewObjectId().Hex()
 	http.Redirect(w, r, fmt.Sprintf("/addmaya-item?objectid=%s", objectID), http.StatusSeeOther)
@@ -113,7 +113,7 @@ func handleAddAlembicProcess(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUploadMaya 함수는 Maya파일을 DB에 업로드하는 페이지를 연다. dropzone에 파일을 올릴 경우 실행된다.
-func handleUploadMaya(w http.ResponseWriter, r *http.Request) {
+func handleUploadMayaFile(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseMultipartForm(200000) // grab the multipart form
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -268,7 +268,7 @@ func handleUploadMaya(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleUploadMayaOnDB(w http.ResponseWriter, r *http.Request) {
+func handleUploadMayaItem(w http.ResponseWriter, r *http.Request) {
 	item := Item{}
 	objectID, err := GetObjectIDfromRequestHeader(r)
 	if err != nil {
@@ -330,7 +330,7 @@ func handleUploadMayaOnDB(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	http.Redirect(w, r, fmt.Sprintf("/addmaya?objectid=%s", objectID), http.StatusSeeOther)
+	http.Redirect(w, r, fmt.Sprintf("/addmaya-file?objectid=%s", objectID), http.StatusSeeOther)
 }
 
 func handleAddMayaSuccess(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
close: #389 

<img width="534" alt="image" src="https://user-images.githubusercontent.com/40417084/77706270-43a11900-7005-11ea-8603-326098ef77d8.png">

1. mongoDB에 item 자료구조를 저장하는 것과 관련된 url은 `-item`으로, 파일을 올리는 것과 관련된 것은 `-file`통일했어요.
1. 형태를 통일시키기 위해 `upload-mayaitem`을 `uploadmaya-item`으로 바꿨어요
1. html파일도  `addmaya-item` `addmaya-file`로 바꿨어요

이름에서 파일을 올리는 과정이 있다는 게 암시되었으면 좋겠다는 의견이 있었는데,
어떻게 해야 그런 느낌이 올지 감이 잘 안와요ㅎ
혹시 좋은 의견 있다면 남겨줘요!