### PR TITLE
파일 이름 태그되게 하기

### DIFF
--- a/http_add.go
+++ b/http_add.go
@@ -471,7 +471,17 @@ func handleUploadMayaFile(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			fmt.Println(tags)
+			for _, tag := range tags {
+				has := false // 중복되는 tag가 있다면 append하지 않는다.
+				for _, t := range item.Tags {
+					if tag == t {
+						has = true
+					}
+				}
+				if !has {
+					item.Tags = append(item.Tags, tag)
+				}
+			}
 		}
 	}
 	UpdateItem(client, "maya", item)

--- a/http_add.go
+++ b/http_add.go
@@ -467,6 +467,11 @@ func handleUploadMayaFile(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "허용하지 않는 파일 포맷입니다", http.StatusBadRequest)
 				return
 			}
+			tags, err := PathToTags(f.Filename)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			fmt.Println(tags)
 		}
 	}
 	UpdateItem(client, "maya", item)

--- a/http_add.go
+++ b/http_add.go
@@ -501,7 +501,7 @@ func handleUploadMayaFile(w http.ResponseWriter, r *http.Request) {
 			}
 			tags, err := FilenameToTags(f.Filename)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				item.Log = item.Log + "\n'" + f.Filename + "'을 tag에 추가하지 못했습니다"
 			}
 			for _, tag := range tags {
 				has := false // 중복되는 tag가 있다면 append하지 않는다.

--- a/http_add.go
+++ b/http_add.go
@@ -499,7 +499,7 @@ func handleUploadMayaFile(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "허용하지 않는 파일 포맷입니다", http.StatusBadRequest)
 				return
 			}
-			tags, err := PathToTags(f.Filename)
+			tags, err := FilenameToTags(f.Filename)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -63,7 +63,7 @@ func PathToTags(path string) ([]string, error) {
 		}
 	}
 	if len(returnTags) == 0 {
-		return returnTags, errors.New("빈 리스트를 반환했습니다")
+		return returnTags, errors.New("태그리스트가 비어있습니다")
 	}
 	return returnTags, nil
 }

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"log"
+	"path/filepath"
 	"strings"
 )
 
@@ -51,12 +52,24 @@ func StringToMap(str string) map[string]string {
 	return result
 }
 
-// SplitBySign 는 string 문자열을 특수문자 기준으로 split하여 리스트를 반환하는 함수이다.
-func SplitBySign(str string) ([]string, error) {
-	var result []string
-	result = regexSplitBySign.Split(str, -1)
-	if len(result) == 0 {
-		return result, errors.New("빈 리스트를 반환했습니다")
+// PathToTags 는 경로를 받아서 태그를 반환한다.
+func PathToTags(path string) ([]string, error) {
+	var returnTags []string
+	filename := strings.TrimSuffix(path, filepath.Ext(path))
+	tags := regexSplitBySign.Split(filename, -1)
+	for _, tag := range tags {
+		has := false // 겹치는 tag가 있다면 append하지 않는다.
+		for _, r := range returnTags {
+			if tag == r {
+				has = true
+			}
+		}
+		if !has {
+			returnTags = append(returnTags, tag)
+		}
 	}
-	return result, nil
+	if len(returnTags) == 0 {
+		return returnTags, errors.New("빈 리스트를 반환했습니다")
+	}
+	return returnTags, nil
 }

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -54,10 +54,16 @@ func StringToMap(str string) map[string]string {
 
 // PathToTags 는 경로를 받아서 태그를 반환한다.
 func PathToTags(path string) ([]string, error) {
+	var returnTags []string
 	filename := strings.TrimSuffix(path, filepath.Ext(path)) // 확장자 제거
 	tags := regexSplitBySign.Split(filename, -1)
-	if len(tags) == 0 {
-		return tags, errors.New("빈 리스트를 반환했습니다")
+	for _, tag := range tags {
+		if tag != "thumbnail" {
+			returnTags = append(returnTags, tag)
+		}
 	}
-	return tags, nil
+	if len(returnTags) == 0 {
+		return returnTags, errors.New("빈 리스트를 반환했습니다")
+	}
+	return returnTags, nil
 }

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -52,8 +52,8 @@ func StringToMap(str string) map[string]string {
 	return result
 }
 
-// PathToTags 는 경로를 받아서 태그를 반환한다.
-func PathToTags(path string) ([]string, error) {
+// FilenameToTags 는 경로를 받아서 태그를 반환한다.
+func FilenameToTags(path string) ([]string, error) {
 	var returnTags []string
 	filename := strings.TrimSuffix(path, filepath.Ext(path)) // 확장자 제거
 	tags := regexSplitBySign.Split(filename, -1)

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -54,22 +54,10 @@ func StringToMap(str string) map[string]string {
 
 // PathToTags 는 경로를 받아서 태그를 반환한다.
 func PathToTags(path string) ([]string, error) {
-	var returnTags []string
-	filename := strings.TrimSuffix(path, filepath.Ext(path))
+	filename := strings.TrimSuffix(path, filepath.Ext(path)) // 확장자 제거
 	tags := regexSplitBySign.Split(filename, -1)
-	for _, tag := range tags {
-		has := false // 겹치는 tag가 있다면 append하지 않는다.
-		for _, r := range returnTags {
-			if tag == r {
-				has = true
-			}
-		}
-		if !has {
-			returnTags = append(returnTags, tag)
-		}
+	if len(tags) == 0 {
+		return tags, errors.New("빈 리스트를 반환했습니다")
 	}
-	if len(returnTags) == 0 {
-		return returnTags, errors.New("빈 리스트를 반환했습니다")
-	}
-	return returnTags, nil
+	return tags, nil
 }

--- a/stringfunc_test.go
+++ b/stringfunc_test.go
@@ -11,11 +11,14 @@ func Test_PathToTags(t *testing.T) {
 		in   string
 		want []string
 	}{{
-		in:   "s0010_c0010_ani_v001", // _ 포함된 경우
+		in:   "s0010_c0010_ani_v001", // _ 포함 경우
 		want: []string{"s0010", "c0010", "ani", "v001"},
 	}, {
-		in:   "s0010_c0010_ani_v001.mb", // 확장자 포함된 경우
+		in:   "s0010_c0010_ani_v001.mb", // 확장자 포함 경우
 		want: []string{"s0010", "c0010", "ani", "v001"},
+	}, {
+		in:   "test_thumbnail.mb", // thumbnail 포함 경우
+		want: []string{"test"},
 	}, {
 		in:   "ani/v001/test", // / 포함 경우
 		want: []string{"ani", "v001", "test"},

--- a/stringfunc_test.go
+++ b/stringfunc_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-//PathToTags 함수가 잘 작동하는지 테스트하는 함수
-func Test_PathToTags(t *testing.T) {
+//FilenameToTags 함수가 잘 작동하는지 테스트하는 함수
+func Test_FilenameToTags(t *testing.T) {
 	cases := []struct {
 		in   string
 		want []string
@@ -34,7 +34,7 @@ func Test_PathToTags(t *testing.T) {
 	},
 	}
 	for _, c := range cases {
-		b, _ := PathToTags(c.in)
+		b, _ := FilenameToTags(c.in)
 		if !reflect.DeepEqual(b, c.want) {
 			t.Fatalf("Test_SplitbySign(): 입력 값: %v, 원하는 값: %v, 얻은 값: %v\n", c.in, c.want, b)
 		}

--- a/stringfunc_test.go
+++ b/stringfunc_test.go
@@ -5,13 +5,16 @@ import (
 	"testing"
 )
 
-//특수문자 기준으로 split하는 함수 SplitbySign이 잘 작동하는지 테스트하는 함수
-func Test_SplitbySign(t *testing.T) {
+//PathToTags 함수가 잘 작동하는지 테스트하는 함수
+func Test_PathToTags(t *testing.T) {
 	cases := []struct {
 		in   string
 		want []string
 	}{{
 		in:   "s0010_c0010_ani_v001", // _ 포함된 경우
+		want: []string{"s0010", "c0010", "ani", "v001"},
+	}, {
+		in:   "s0010_c0010_ani_v001.mb", // 확장자 포함된 경우
 		want: []string{"s0010", "c0010", "ani", "v001"},
 	}, {
 		in:   "ani/v001/test", // / 포함 경우
@@ -28,7 +31,7 @@ func Test_SplitbySign(t *testing.T) {
 	},
 	}
 	for _, c := range cases {
-		b, _ := SplitBySign(c.in)
+		b, _ := PathToTags(c.in)
 		if !reflect.DeepEqual(b, c.want) {
 			t.Fatalf("Test_SplitbySign(): 입력 값: %v, 원하는 값: %v, 얻은 값: %v\n", c.in, c.want, b)
 		}


### PR DESCRIPTION
close: #417 

- handleUploadMayaFile에서 item 업데이트 전에 파일이름들 item.Tags에 append함
- SplitBySign 함수명 PathToTags로 변경
- 파일 이름에서 확장자 떼고 태그에 추가되게 함
- 태그가 중복되면 append 하지 않는 기능 추가

<img width="566" alt="스크린샷 2020-04-14 오전 9 16 26" src="https://user-images.githubusercontent.com/46209590/79172998-44251680-7e31-11ea-8c39-21c25cb7fab1.png">
<img width="579" alt="스크린샷 2020-04-14 오전 9 16 43" src="https://user-images.githubusercontent.com/46209590/79173004-47b89d80-7e31-11ea-811f-6e42b45c3d06.png">
<img width="421" alt="스크린샷 2020-04-14 오전 9 17 03" src="https://user-images.githubusercontent.com/46209590/79173006-48e9ca80-7e31-11ea-92b1-e143b76678a2.png">
