### PR TITLE
아이템이 생성됨과 동시에 로그를 남김

### DIFF
--- a/http_add.go
+++ b/http_add.go
@@ -267,6 +267,7 @@ func handleUploadMayaItem(w http.ResponseWriter, r *http.Request) {
 	}
 	item.Attributes = attr
 	item.Status = "ready"
+	item.Logs = append(item.Logs, "아이템이 생성되었습니다.")
 	currentTime := time.Now()
 	item.CreateTime = currentTime.Format("2006-01-02 15:04:05")
 	item.ThumbImgUploaded = false


### PR DESCRIPTION
close: #616 

- 로그없이 생성되면 log가 null로 인식되서 `$push`를 쓸 수 없다
- 생성과 동시에 로그를 남길 경우 SetLog에서 에러가 나지 않는 것 확인 완료.