### PR TITLE
footage 일때는 Download 버튼이 보이면 안된다.

### DIFF
--- a/assets/template/items.html
+++ b/assets/template/items.html
@@ -25,7 +25,9 @@
                     <div class="ml-1">
                         <a href="/edit{{.ItemType}}?itemtype={{.ItemType}}&id={{.ID.Hex}}" class="badge badge-outline-darkmode">Edit</a>
                         <button class="finger badge badge-outline-darkmode" onclick="copyButton(this.value)" value="{{.OutputDataPath}}">Copy Path</button>
-                        <a href="/download-item?itemtype={{.ItemType}}&id={{.ID.Hex}}" class="finger badge badge-outline-darkmode">Download</a>
+                        {{if ne .ItemType "footage"}}
+                            <a href="/download-item?itemtype={{.ItemType}}&id={{.ID.Hex}}" class="finger badge badge-outline-darkmode">Download</a>
+                        {{end}}
                         {{if eq $.User.AccessLevel "admin"}}
                             <button class="finger badge badge-danger" data-toggle="modal" data-target="#modal-rmitem" onclick="setRmItemModal('{{.ID.Hex}}')">Delete</button>
                         {{end}}


### PR DESCRIPTION
Close: #673 

<img width="424" alt="image" src="https://user-images.githubusercontent.com/1149996/81699796-c5a8ac80-94a2-11ea-8a17-494929e7c667.png">

사라짐.

사유: Footage는 일반적으로 용량이 굉장히 크고, 서버에서 Path만 복사하여 당겨쓰는 형태가 많다. 보통용량이 아니다.