### PR TITLE
data 삭제 함수 추가 

### DIFF
--- a/http_restapi.go
+++ b/http_restapi.go
@@ -118,7 +118,13 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		err = RmItem(client, itemtype, id)
+		// 삭제 함수 호출
+		err = RmItem(client, itemtype, id) // db 에서 삭제
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = RmData(client, id) // 실제 데이터 삭제
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pathfunc.go
+++ b/pathfunc.go
@@ -173,6 +173,8 @@ func RmData(client *mongo.Client, id string) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			break
 		}
 		if splitpath == rootpath {
 			break

--- a/pathfunc.go
+++ b/pathfunc.go
@@ -166,7 +166,10 @@ func RmData(client *mongo.Client, id string) error {
 	for {
 		splitpath, _ = path.Split(splitpath)
 		splitpath = strings.TrimSuffix(splitpath, "/")
-		c, _ := ioutil.ReadDir(splitpath)
+		c, err := ioutil.ReadDir(splitpath)
+		if err != nil {
+			return err
+		}
 		// 하위 폴더 없으면 삭제
 		if len(c) == 0 {
 			err := os.Remove(splitpath)


### PR DESCRIPTION
### test 방법
```
curl -X DELETE "http://192.168.0.9/api/item?itemtype=maya&id=5ec0332ae1825e3ada5bf2e3"
```
- pathfunc.go에 RmData 함수 추가
- 최하단 경로는 ```os.RemoveAll```로 한꺼번에 삭제한 후 차례차례 올라가면서 빈 폴더인지 확인하고 삭제함
- /api/item restapi에 delete 메소드로 요청 시 같이 실행되도록 적용
- 삭제 경로를 item 자료구조에서 가져올까 rootpath랑 idpath 합쳐서 만들까 고민하다가 후자 선택함. 
- **에러 처리 이렇게 하는 거 맞는지 모르겠네요! 확인 plz**

close: #528 