### PR TITLE
에러처리가 잘못된것 수정함.

### DIFF
--- a/http_restapi.go
+++ b/http_restapi.go
@@ -121,7 +121,7 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 		//accesslevel 체크
 		accesslevel, err := GetAccessLevelFromToken(r, client)
 		if accesslevel != "admin" {
-			http.Error(w, "삭제 권한이 없는 계정입니다", http.StatusBadRequest)
+			http.Error(w, "삭제 권한이 없는 계정입니다", http.StatusUnauthorized)
 			return
 		}
 

--- a/middleware.go
+++ b/middleware.go
@@ -77,6 +77,7 @@ func GetAccessLevelFromToken(r *http.Request, client *mongo.Client) (string, err
 		return "", errors.New("authorization failed")
 	}
 	token := auth[1]
+
 	//DB 검색
 	collection := client.Database(*flagDBName).Collection("users")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Close: #734 

curl을 이용해서 token sign키 정보를 보내는 것보다는 DB에 접근해서 엑세스 레벨을 가지고 오는 것이 더 낳은 것 같다.
코드를 그대로 둔다.