### PR TITLE
usd 추가 페이지에 USD 종류 선택란 추가

### DIFF
--- a/assets/template/addusd-item.html
+++ b/assets/template/addusd-item.html
@@ -38,6 +38,19 @@
         <div class="row">
             <div class="col-sm">
                 <div class="form-group">
+                    <label class="text-muted">Pixar USD kind setting</label>
+                    <select name="Construction" class="form-control">
+                        <option value="component">Component</option>
+                        <option value="group">Group</option>
+                        <option value="assembly">Assembly</option>
+                    </select>
+                    <small class="form-text text-muted">.usd 에셋 구성 형태를 선택해주세요.</small>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm">
+                <div class="form-group">
                     <label class="text-muted">Attributes</label>
                     <div id="attributes">
                         <div class="row">


### PR DESCRIPTION
close: #738 
일단 페이지 디자인만 수정해놓았어요. 기능은 좀 더 고민해보고 다른 PR로 올릴게요
<img width="602" alt="image" src="https://user-images.githubusercontent.com/40417084/82878992-4b365d00-9f77-11ea-8c87-163831d29abf.png">
