### PR TITLE
build.sh 에서 윈도우즈용 빌드 옵션 제거

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,11 @@ go run assets/asset_generate.go
 APP="dotori"
 GOOS=linux GOARCH=amd64 go build -o ./bin/linux/${APP} *.go
 GOOS=darwin GOARCH=amd64 go build -o ./bin/darwin/${APP} *.go
-GOOS=windows GOARCH=amd64 go build -o ./bin/windows/${APP} *.go
 
 # Github Release에 업로드 하기위해 압축
 cd ./bin/linux/ && tar -zcvf ../${APP}_linux_x86-64.tgz . && cd -
 cd ./bin/darwin/ && tar -zcvf ../${APP}_darwin_x86-64.tgz . && cd -
-cd ./bin/windows/ && tar -zcvf ../${APP}_windows_x86-64.tgz . && cd -
 
 # 삭제
 rm -rf ./bin/linux
 rm -rf ./bin/darwin
-rm -rf ./bin/windows


### PR DESCRIPTION
Close: #884 

- 동시접속자 문제로 윈도우즈 서버가 아니면 큰 의미가 없다.
- Umask 옵션이 있어서 윈도우즈서 빌드시 에러가 난다.