### PR TITLE
defer cancel 처리

### DIFF
--- a/process.go
+++ b/process.go
@@ -29,8 +29,8 @@ func ProcessMain() {
 		log.Println(err)
 		return
 	}
-	ctx, cancle := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancle()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	err = client.Connect(ctx)
 	if err != nil {
 		log.Println(err)
@@ -48,7 +48,7 @@ func ProcessMain() {
 		return
 	}
 	client.Disconnect(ctx)
-	cancle()
+	cancel()
 
 	// 버퍼 채널을 만든다.
 	jobs := make(chan Item, adminSetting.ProcessBufferSize)

--- a/process.go
+++ b/process.go
@@ -29,7 +29,8 @@ func ProcessMain() {
 		log.Println(err)
 		return
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancle := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancle()
 	err = client.Connect(ctx)
 	if err != nil {
 		log.Println(err)
@@ -47,6 +48,7 @@ func ProcessMain() {
 		return
 	}
 	client.Disconnect(ctx)
+	cancle()
 
 	// 버퍼 채널을 만든다.
 	jobs := make(chan Item, adminSetting.ProcessBufferSize)


### PR DESCRIPTION
close: #964 
processMain함수는 끝나지 않으니까 defer cancel을 없앴는데
중간에 에러를 만나서 끝나는 경우가 문제가 됨.

- defer cancel() 추가
- 뒤에서 수동으로 cancel()도 한 번 해줌