### PR TITLE
devmode 추가함

### DIFF
--- a/dotori.go
+++ b/dotori.go
@@ -29,6 +29,7 @@ var (
 	flagGetOngoingProcess = flag.Bool("getongoingprocess", false, "get ongoing process")  // 완료되지 않은 프로세스를 가져옵니다.
 	flagProcess           = flag.Bool("process", false, "start processing item")          // 프로세스를 실행시킨다
 	flagDebug             = flag.Bool("debug", false, "debug mode")                       // debug모드
+	flagDevMode           = flag.Bool("devmode", false, "devel mode")                     // 개발모드 활성화
 	flagAccesslevel       = flag.String("accesslevel", "default", "access level of user") // 사용자의 accesslevel을 지정합니다. admin, manager, default
 
 	flagAuthor             = flag.String("author", "", "author")


### PR DESCRIPTION
Close: #1060 

우리는 언제나 잘 도는 서버를 개발해야하니.. 불안정한 현 개발중인 곳에 잘 써주세요.

개발 모드일때만 코드부가 실행되도록 하는 코드흐름

```go
if *flagDevMode {
    // 개발모드로 실행했을 때 실행되어야 하는 코드
}
```

개발모드로 실행하기.
```bash
$ doter -http :80 -devmode
```