### PR TITLE
태그가 긴 상황에서 에러 케이스 추가함.

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -293,7 +293,7 @@ func Test_Tag(t *testing.T) {
 		Tag:  "tag태그", // 영문, 한글이 포함된 경우
 		want: true,
 	}, {
-		Tag:  "비밀유지서약서", // 영문, 한글이 포함된 경우
+		Tag:  "비밀유지서약서", // 긴 길이의 태그
 		want: true,
 	}, {
 		Tag:  "tag2", // 숫자가 포함된 경우

--- a/check_test.go
+++ b/check_test.go
@@ -293,6 +293,9 @@ func Test_Tag(t *testing.T) {
 		Tag:  "tag태그", // 영문, 한글이 포함된 경우
 		want: true,
 	}, {
+		Tag:  "비밀유지서약서", // 영문, 한글이 포함된 경우
+		want: true,
+	}, {
 		Tag:  "tag2", // 숫자가 포함된 경우
 		want: true,
 	}, {


### PR DESCRIPTION
Close: #1123 

실제로 입력 오타였다. 하지만 다른 사람의 심리적 검증을 위해서 케이스를 넣어둔다.

![image](https://user-images.githubusercontent.com/1149996/89592235-14d66180-d887-11ea-8f5f-a3237cbcdbbe.png)
