### PR TITLE
RestAPI : 파일 업로드 기능 추가

### DIFF
--- a/http_alembic.go
+++ b/http_alembic.go
@@ -230,6 +230,11 @@ func handleUploadAlembicFile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	uploadAlembicFile(w, r, objectID)
+}
+
+// uploadAlembicFile 함수는 Alembic 파일 정보를 DB에 업로드하고 파일을 storage에 복사한다.
+func uploadAlembicFile(w http.ResponseWriter, r *http.Request, objectID string) {
 	//mongoDB client 연결
 	client, err := mongo.NewClient(options.Client().ApplyURI(*flagMongoDBURI))
 	if err != nil {
@@ -316,6 +321,9 @@ func handleUploadAlembicFile(w http.ResponseWriter, r *http.Request) {
 			defer file.Close()
 			unix.Umask(umask)
 			mimeType := f.Header.Get("Content-Type")
+			fmt.Println("------------")
+			fmt.Println(mimeType)
+			fmt.Println(f.Filename)
 			switch mimeType {
 			case "image/jpeg", "image/png":
 				data, err := ioutil.ReadAll(file)

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -127,6 +127,10 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 		item, err := GetItem(client, i.ID.Hex())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Failed to Upload Asset"))
+			return
 		}
 		data, _ := json.Marshal(item)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
 merge 하려는 pr은 아니구요! 질문하려고 올렸어요.
#1004 에서 **방법2**대로 진행했는데요! ```multipart/mixed``` 가 아니더라도 ```multipart/form-data```로 충분히 json과 파일을 동시에 request 할 수 있을 것 같아서 바꿨어요.

이렇게 했을 때 jpg나 .abc는 올라가는데 mov는 mimetype이 ```application/octet-stream```으로 찍히고 .zip은 아예 안가더라구요. 원인을 모르겠어서... 같이 고민해주셨으면 해서 올렸슴당

ps. 지난주에 얘기했던 내용(restapi와 handler는 함수를 분리하기)과는 다르게 ```uploadAlembicFile``` 부분을 찢어놨는데요! http_alembic.go를 handler라는 의미로만 보지 않고, http를 통할 때의 alembic 파일 처리라는 범주 안에서 생각해보면 이 방향도 괜찮을 것 같아서 일단 file upload 부분은 http_alembic.go의 ```uploadAlembicFile``` 함수를 호출하도록 해봤어요! 다른 의견이시면 말씀주세용

