### PR TITLE
RestAPI, Download: 아이템 get, 삭제, 다운로드 시 itemtype 빈문자열에 대한 에러처리 제거

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -51,9 +51,9 @@ function setRmItemModal(itemtype, itemId) {
 }
 
 // setDetailViewModal 은 아이템을 선택했을 때 볼 수 있는 detailview 모달창에 detail 정보를 세팅해주는 함수이다.
-function setDetailViewModal(itemtype, itemid) {
+function setDetailViewModal(itemid) {
     $.ajax({
-        url: `/api/item?itemtype=${itemtype}&id=${itemid}`,
+        url: `/api/item?id=${itemid}`,
         type: "get",
         dataType: "json",
         success: function(response) {
@@ -63,11 +63,11 @@ function setDetailViewModal(itemtype, itemid) {
             document.getElementById("modal-detailview-description").innerHTML = response["description"];
             let outputdatapath=response["outputdatapath"]
             let footerHtml = `
-            <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?itemtype=${itemtype}&id=${itemid}'">Download</button>
+            <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?id=${itemid}'">Download</button>
             <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-copypath-button" onclick="copyButton('${outputdatapath}')">Copy Path</button>
             `
             let footerHtmlForAdmin=`
-            <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?itemtype=${itemtype}&id=${itemid}'">Download</button>
+            <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?id=${itemid}'">Download</button>
             <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-copypath-button" onclick="copyButton('${outputdatapath}')">Copy Path</button>
             <button type="button" class="btn btn-outline-danger" id="modal-detailview-delete-button" data-dismiss="modal" data-toggle="modal" data-target="#modal-rmitem" onclick="setRmItemModal('${itemtype}','${itemid}')">Delete</button>
             `
@@ -76,7 +76,7 @@ function setDetailViewModal(itemtype, itemid) {
             } else {
                 document.getElementById("modal-detailview-footer").innerHTML = footerHtml
             }
-            if (itemtype == "footage") {
+            if (response["itemtype"] == "footage") {
                 document.getElementById("modal-detailview-download-button").style.visibility="hidden"        
             }
         },

--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -44,12 +44,6 @@ function copyButton(elementId) {
     document.getElementById("modal-detailview").removeChild(id);    // modal에서 요소 삭제
 }
 
-// setRmItemModal 은 아이템 삭제 버튼을 누르면 id값을 받아 modal창에 보여주는 함수이다.
-function setRmItemModal(itemtype, itemId) {
-    document.getElementById("modal-rmitem-itemtype").value = itemtype;
-    document.getElementById("modal-rmitem-itemid").value = itemId;
-}
-
 // setDetailViewModal 은 아이템을 선택했을 때 볼 수 있는 detailview 모달창에 detail 정보를 세팅해주는 함수이다.
 function setDetailViewModal(itemid) {
     $.ajax({
@@ -69,9 +63,10 @@ function setDetailViewModal(itemid) {
             let footerHtmlForAdmin=`
             <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?id=${itemid}'">Download</button>
             <button type="button" class="btn btn-outline-darkmode" id="modal-detailview-copypath-button" onclick="copyButton('${outputdatapath}')">Copy Path</button>
-            <button type="button" class="btn btn-outline-danger" id="modal-detailview-delete-button" data-dismiss="modal" data-toggle="modal" data-target="#modal-rmitem" onclick="setRmItemModal('${itemtype}','${itemid}')">Delete</button>
+            <button type="button" class="btn btn-outline-danger" id="modal-detailview-delete-button" data-dismiss="modal" data-toggle="modal" data-target="#modal-rmitem">Delete</button>
             `
             if (document.getElementById("accesslevel").value == "admin") {
+                document.getElementById("modal-rmitem-itemid").value = itemid;
                 document.getElementById("modal-detailview-footer").innerHTML = footerHtmlForAdmin
             } else {
                 document.getElementById("modal-detailview-footer").innerHTML = footerHtml
@@ -88,21 +83,21 @@ function setDetailViewModal(itemid) {
 }
 
 // rmItemModal 은 삭제 modal창에서 Delete 버튼을 누르면 실행되는 아이템 삭제 함수이다. 
-function rmItemModal(itemtype,itemId) {
+function rmItemModal(itemId) {
     let token = document.getElementById("token").value;
     $.ajax({
-        url: `/api/item?itemtype=${itemtype}&id=${itemId}`,
+        url: `/api/item?id=${itemId}`,
         type: "delete",
         headers: {
             "Authorization": "Basic " + token
         },
         dataType: "json",
         success: function() {
-            alert("itemtype: "+itemtype+"\nid: "+itemId+"\n\n아이템 삭제를 성공했습니다."); 
+            alert("id: "+itemId+"\n\n아이템 삭제를 성공했습니다."); 
             location.reload();
         },
         error: function(){
-            alert("itemtype: "+itemtype+"\nid: "+itemId+"\n\n아이템 삭제를 실패했습니다.");  
+            alert("id: "+itemId+"\n\n아이템 삭제를 실패했습니다.");  
         }
     });
 }

--- a/assets/template/items.html
+++ b/assets/template/items.html
@@ -24,7 +24,7 @@
                                 Your browser does not support the video tag.
                             </video>
                         {{end}}    
-                    <div class="card-body" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ItemType}}','{{.ID.Hex}}')">
+                    <div class="card-body" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
                         <h5 class="card-title">{{.Title}}</h5>
                         <div class="row m-0 mb-2"style="align-items: center;">
                             <i class="fas fa-download fa-xs" style="color:grey;"></i>

--- a/assets/template/modal.html
+++ b/assets/template/modal.html
@@ -14,7 +14,6 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <input type="hidden" class="form-control" id="modal-rmitem-itemtype">
                     <div class="form-group">
                         <label for="modal-rmitem-itemid" class="col-form-label">아래 에셋을 삭제하겠습니까?</label>
                         <textarea class="form-control" style="color:#fff;" id="modal-rmitem-itemid" rows="2" disabled></textarea>
@@ -22,7 +21,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-outline-darkmode" data-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-outline-danger" onclick="rmItemModal(document.getElementById('modal-rmitem-itemtype').value,getElementById('modal-rmitem-itemid').value)">Delete</button>
+                    <button type="button" class="btn btn-outline-danger" onclick="rmItemModal(document.getElementById('modal-rmitem-itemid').value)">Delete</button>
                 </div>
             </div>
         </div>

--- a/http_download.go
+++ b/http_download.go
@@ -25,12 +25,7 @@ func handleDownloadItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := r.URL.Query()
-	itemtype := q.Get("itemtype")
 	id := q.Get("id")
-	if itemtype == "" {
-		http.Error(w, "URL에 itemtype을 입력해주세요", http.StatusBadRequest)
-		return
-	}
 	if id == "" {
 		http.Error(w, "URL에 id를 입력해주세요", http.StatusBadRequest)
 		return

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -140,12 +140,7 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 
 	} else if r.Method == http.MethodDelete {
 		q := r.URL.Query()
-		itemtype := q.Get("itemtype")
 		id := q.Get("id")
-		if itemtype == "" {
-			http.Error(w, "URL에 itemtype을 입력해주세요", http.StatusBadRequest)
-			return
-		}
 		if id == "" {
 			http.Error(w, "URL에 id를 입력해주세요", http.StatusBadRequest)
 			return

--- a/http_restapi.go
+++ b/http_restapi.go
@@ -199,12 +199,7 @@ func handleAPIItem(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if r.Method == http.MethodGet {
 		q := r.URL.Query()
-		itemtype := q.Get("itemtype")
 		id := q.Get("id")
-		if itemtype == "" {
-			http.Error(w, "URL에 itemtype을 입력해주세요", http.StatusBadRequest)
-			return
-		}
 		if id == "" {
 			http.Error(w, "URL에 id를 입력해주세요", http.StatusBadRequest)
 			return


### PR DESCRIPTION
close: #1191 

DB에서 itemtype을 collection으로 나누지 않기로 했을 때부터 itemtype에 대한 정보 없이 아이템 get, 삭제, 다운로드가 가능해졌는데요 아직 restapi, download 함수에 itemtype이 빈문자열일 때의 에러처리가 들어있었어서 그 부분 제거했습니다!

수정한 거에 맞춰서 각 함수로 연결된 버튼들도 수정했습니다