### PR TITLE
hdri 아이템이 연산과정에서 에러가 난 경우, 프로세스 목록에 뜨지 않던 이슈 해결 및 리팩토링

### DIFF
--- a/assets/template/help_search.html
+++ b/assets/template/help_search.html
@@ -14,7 +14,6 @@
 						<option value="nuke" >Nuke</option>
 						<option value="houdini" >Houdini</option>
 						<option value="footage" >Footage</option>
-						<option value="psd" >PSD</option>
 						<option value="pdf" >PDF</option>
 						<option value="lut" >LUT</option>
 						<option value="ies" >IES</option>

--- a/assets/template/search.html
+++ b/assets/template/search.html
@@ -22,7 +22,6 @@
 						<option value="hwp" {{if eq .ItemType "hwp" }}selected{{end}}>HWP</option>
 						<option value="pdf" {{if eq .ItemType "pdf" }}selected{{end}}>PDF</option>
 						<option value="ppt" {{if eq .ItemType "ppt" }}selected{{end}}>PPT</option>
-						<option value="psd" {{if eq .ItemType "psd" }}selected{{end}}>PSD</option>						
 						<option value="lut" {{if eq .ItemType "lut" }}selected{{end}}>LUT</option>
 						<option value="ies" {{if eq .ItemType "ies" }}selected{{end}}>IES</option>
 						<option value="hdri" {{if eq .ItemType "hdri" }}selected{{end}}>HDRI</option>

--- a/dbapi.go
+++ b/dbapi.go
@@ -468,23 +468,8 @@ func GetOngoingProcess(client *mongo.Client) ([]Item, error) {
 	var results []Item
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	filter := bson.M{"$and": []interface{}{
-		// 프로세스가 필요한 아이템 타입
-		bson.M{"$or": []interface{}{
-			bson.M{"itemtype": "maya"},
-			bson.M{"itemtype": "max"},
-			bson.M{"itemtype": "fusion360"},
-			bson.M{"itemtype": "nuke"},
-			bson.M{"itemtype": "houdini"},
-			bson.M{"itemtype": "blender"},
-			bson.M{"itemtype": "footage"},
-			bson.M{"itemtype": "alembic"},
-			bson.M{"itemtype": "usd"},
-			bson.M{"itemtype": "clip"},
-		}},
-		// 조건: 프로세스가 종료되지 않은 모든 아이템
-		bson.M{"status": bson.M{"$ne": "done"}},
-	}}
+	// 조건: 프로세스가 종료되지 않은 모든 아이템
+	filter := bson.M{"status": bson.M{"$ne": "done"}}
 	cursor, err := client.Database(*flagDBName).Collection("items").Find(ctx, filter)
 	if err != nil {
 		return results, err

--- a/process.go
+++ b/process.go
@@ -249,8 +249,6 @@ func processingItem(item Item) {
 			return
 		}
 		return
-	case "psd": // 포토샵 파일
-		return
 	case "modo": // 모도
 		err = ProcessModoItem(client, adminSetting, item)
 		if err != nil {
@@ -303,6 +301,16 @@ func processingItem(item Item) {
 		return
 	case "hwp":
 		err = ProcessHwpItem(client, adminSetting, item)
+		if err != nil {
+			err = SetErrStatus(client, item.ID.Hex(), err.Error())
+			if err != nil {
+				log.Println(err)
+			}
+			return
+		}
+		return
+	case "ppt":
+		err = ProcessPptItem(client, adminSetting, item)
 		if err != nil {
 			err = SetErrStatus(client, item.ID.Hex(), err.Error())
 			if err != nil {
@@ -1756,8 +1764,18 @@ func ProcessPdfItem(client *mongo.Client, adminSetting Adminsetting, item Item) 
 	return nil
 }
 
-// ProcessHwpItem 함수는 PDF 아이템을 연산한다.
+// ProcessHwpItem 함수는 Hwp 아이템을 연산한다.
 func ProcessHwpItem(client *mongo.Client, adminSetting Adminsetting, item Item) error {
+	// 아무 프로세스는 없지만 "done" 처리 해야한다. 그래야 프로세싱하지 않는다.
+	err := SetStatus(client, item, "done")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ProcessPptItem 함수는 PPT 아이템을 연산한다.
+func ProcessPptItem(client *mongo.Client, adminSetting Adminsetting, item Item) error {
 	// 아무 프로세스는 없지만 "done" 처리 해야한다. 그래야 프로세싱하지 않는다.
 	err := SetStatus(client, item, "done")
 	if err != nil {


### PR DESCRIPTION
- 프로세스가 종료되지 않은 모든 아이템을 가져오는 함수, `GetOngoingProcess`의 조건 수정.
    - 프로세스가 필요한 아이템의 종류를 추가하는 방식에서
    - done이 아닌 모든 아이템을 가져오는 방식으로 수정
- 대신 모든 아이템타입에 프로세스 함수를 추가함.
    - 프로세스 함수가 빠져있던 아이템 타입: ppt
- 현재 psd타입은 add기능이 구현되어 있지 않아서 프로세스를 비롯해 드롭다운 등등에서 모두 삭제함