### PR TITLE
GetIncompleteItems 함수 리팩토링

### DIFF
--- a/dbapi.go
+++ b/dbapi.go
@@ -567,6 +567,7 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 
 	filter := bson.M{"$or": []interface{}{
 		// maya, max, fusion360, nuke, houdini, blender, footage, alembic, usd, modo, katana, openvdb 아이템타입의 조건
+		// 필요 조건: 썸네일 이미지, 썸네일 클립, 데이터
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
@@ -591,6 +592,7 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 			}},
 		}},
 		// sound, pdf, hwp, texture, clip, ies, ppt, unreal 타입 아이템의 조건
+		// 필요 조건: 데이터
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
@@ -608,6 +610,7 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 			bson.M{"datauploaded": false},
 		}},
 		// lut, hdri 타입 아이템의 조건
+		// 필요 조건: 썸네일 이미지, 데이터
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{

--- a/dbapi.go
+++ b/dbapi.go
@@ -560,7 +560,7 @@ func SetLog(client *mongo.Client, id, msg string) error {
 	return nil
 }
 
-//GetIncompleteItems 함수는 썸네일 이미지, 썸네일 클립, 데이터 중 하나라도 없는 아이템을 모두 가져온다.
+//GetIncompleteItems 함수는 프로세스 이후 필요한 정보(썸네일 이미지, 썸네일 클립, 데이터 등)가 없는 아이템을 가지고 온다.
 func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 	var results []Item
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/dbapi.go
+++ b/dbapi.go
@@ -590,14 +590,13 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 				bson.M{"datauploaded": false},
 			}},
 		}},
-		// sound, pdf, hwp, hdri, texture, clip, ies, ppt, unreal 타입 아이템의 조건
+		// sound, pdf, hwp, texture, clip, ies, ppt, unreal 타입 아이템의 조건
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
 				bson.M{"itemtype": "sound"},
 				bson.M{"itemtype": "pdf"},
 				bson.M{"itemtype": "hwp"},
-				bson.M{"itemtype": "hdri"},
 				bson.M{"itemtype": "texture"},
 				bson.M{"itemtype": "lut"},
 				bson.M{"itemtype": "clip"},
@@ -608,11 +607,12 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 			// 조건
 			bson.M{"datauploaded": false},
 		}},
-		// lut 타입 아이템의 조건
+		// lut, hdri 타입 아이템의 조건
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
 				bson.M{"itemtype": "lut"},
+				bson.M{"itemtype": "hdri"},
 			}},
 			// 조건
 			bson.M{"$or": []interface{}{

--- a/dbapi.go
+++ b/dbapi.go
@@ -566,7 +566,7 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 	defer cancel()
 
 	filter := bson.M{"$or": []interface{}{
-		// maya, max, fusion360, nuke, houdini, blender, footage, alembic, usd 아이템타입의 조건
+		// maya, max, fusion360, nuke, houdini, blender, footage, alembic, usd, modo, katana, openvdb 아이템타입의 조건
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
@@ -579,6 +579,9 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 				bson.M{"itemtype": "footage"},
 				bson.M{"itemtype": "alembic"},
 				bson.M{"itemtype": "usd"},
+				bson.M{"itemtype": "modo"},
+				bson.M{"itemtype": "katana"},
+				bson.M{"itemtype": "openvdb"},
 			}},
 			// 조건
 			bson.M{"$or": []interface{}{
@@ -587,7 +590,7 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 				bson.M{"datauploaded": false},
 			}},
 		}},
-		// sound, pdf, hwp, hdri, texture, lut, clip, ies 타입 아이템의 조건
+		// sound, pdf, hwp, hdri, texture, clip, ies, ppt, unreal 타입 아이템의 조건
 		bson.M{"$and": []interface{}{
 			// 아이템 타입
 			bson.M{"$or": []interface{}{
@@ -599,9 +602,23 @@ func GetIncompleteItems(client *mongo.Client) ([]Item, error) {
 				bson.M{"itemtype": "lut"},
 				bson.M{"itemtype": "clip"},
 				bson.M{"itemtype": "ies"},
+				bson.M{"itemtype": "ppt"},
+				bson.M{"itemtype": "unreal"},
 			}},
 			// 조건
 			bson.M{"datauploaded": false},
+		}},
+		// lut 타입 아이템의 조건
+		bson.M{"$and": []interface{}{
+			// 아이템 타입
+			bson.M{"$or": []interface{}{
+				bson.M{"itemtype": "lut"},
+			}},
+			// 조건
+			bson.M{"$or": []interface{}{
+				bson.M{"thumbimguploaded": false},
+				bson.M{"datauploaded": false},
+			}},
 		}},
 	}}
 


### PR DESCRIPTION
close: #1222 

- 빠진 아이템 타입 추가
- lut, hdri 타입 분리
    - lut, hdri 타입의 조건이 다르기 때문.
    - lut, hdri 타입의 필요 조건: 썸네일 이미지, 데이터