### PR TITLE
windows에서 경로복사시 UNC 경로앞에 붙는 prefix 문자열 설정 옵션 추가.

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -36,10 +36,26 @@ document.onkeydown = function(e) {
 
 // copyButton 은 아이디값을 받아서, 클립보드로 복사하는 기능이다.
 function copyButton(elementId) {
-    if (navigator.userAgent.indexOf("Win") != -1) {
+    let windowsUNCPrefix = "";
+    $.ajax({
+        url: `/api/adminsetting`,
+        type: "get",
+        headers: {
+            "Authorization": "Basic " + document.getElementById("token").value
+        },
+        dataType: "json",
+        async: false,
+        success: function(data) {
+            windowsUNCPrefix = data.windowsuncprefix;
+        },
+        error: function(){
+            alert("admin 셋팅에서 Windows UNC Prefix 값을 가지고 올 수 없습니다.");  
+        }
+    });
+    if (navigator.userAgent.indexOf("Win") != -1) { // windows 경우
         elementId = elementId.replace(/\//g, "\\")
-        elementId = "\\" + elementId
-    } 
+        elementId = windowsUNCPrefix + elementId
+    }
     let id = document.createElement("input");                       // input요소를 만듬
     id.setAttribute("value", elementId);                            // input요소에 값을 추가
     document.getElementById("modal-detailview").appendChild(id);    // modal에 요소 추가

--- a/assets/template/adminsetting.html
+++ b/assets/template/adminsetting.html
@@ -56,6 +56,15 @@
                 <div class="row">
                     <div class="col-sm">
                         <div class="form-group">
+                            <label class="text-muted">Windows UNC Prefix</label>
+                            <input type="text" name="windowsuncprefix" class="form-control" placeholder="\" value="{{.Adminsetting.WindowsUNCPrefix}}">
+                            <small class="form-text text-muted">Windows에서 CopyPath를 실행했을 때 UNC 경로 앞에 붙는 문자열</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm">
+                        <div class="form-group">
                             <label class="text-muted">Umask</label>
                             <input type="text" name="umask" class="form-control" placeholder="0000" value="{{.Adminsetting.Umask}}" maxlength="4" onkeyup=handlerNumCheck(this)>
                             <small class="form-text text-muted">Umask 값을 설정해주세요.</small>

--- a/http_adminsetting.go
+++ b/http_adminsetting.go
@@ -70,6 +70,7 @@ func handleAdminSettingSubmit(w http.ResponseWriter, r *http.Request) {
 	a.LinuxProtocolPath = r.FormValue("linuxprotocolpath")
 	a.WindowsProtocolPath = r.FormValue("windowsprotocolpath")
 	a.MacosProtocolPath = r.FormValue("macosprotocolpath")
+	a.WindowsUNCPrefix = r.FormValue("windowsuncprefix")
 	a.Umask = r.FormValue("umask")
 	a.FolderPermission = r.FormValue("folderpermission")
 	a.FilePermission = r.FormValue("filepermission")

--- a/struct_adminsetting.go
+++ b/struct_adminsetting.go
@@ -13,6 +13,7 @@ type Adminsetting struct {
 	LinuxProtocolPath       string `json:"linuxprotocolpath" bson:"linuxprotocolpath"`             // 웹에서 클릭시 사용하는 Linux 경로
 	WindowsProtocolPath     string `json:"windowsprotocolpath" bson:"windowsprotocolpath"`         // 웹에서 클릭시 사용하는 Windows 경로
 	MacosProtocolPath       string `json:"macosprotocolpath" bson:"macosprotocolpath"`             // 웹에서 클릭시 사용하는 macOS 경로
+	WindowsUNCPrefix        string `json:"windowsuncprefix" bson:"windowsuncprefix"`               // CopyPath를 실행할 때 윈도우즈의 경우 경로 앞에 붙는 문자열
 	Umask                   string `json:"umask" bson:"umask"`                                     // Umask 값
 	FolderPermission        string `json:"folderpermission" bson:"folderpermission"`               // 폴더 생성시 사용하는 권한
 	FilePermission          string `json:"filepermission" bson:"filepermission"`                   // 파일 생성시 사용하는 권한


### PR DESCRIPTION
Close: #1251 

![image](https://user-images.githubusercontent.com/1149996/92140001-846e4b00-ee4b-11ea-9def-2547d76eff59.png)
