### PR TITLE
최초 안내 페이지: next 버튼 누르고 card 눌렀을 때 그 전 페이지 item detail view 뜨는 버그 수정

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -301,6 +301,7 @@ function recentlyClick(totalItemNum, buttonState) {
                     }
                 }
                 recentlyImageForm.innerHTML = img;
+                document.getElementById("recentCardBody"+i).onclick = function () { setDetailViewModal(data[i].id);}
                 document.getElementById("recentlyTitle"+i).innerHTML = data[i].title;
                 document.getElementById("recentlyCreateTime"+i).innerHTML = data[i].createtime.split('T')[0];
             }
@@ -379,6 +380,7 @@ function topUsingClick(totalItemNum, buttonState) {
                     }
                 }
                 topUsingImageForm.innerHTML = img;
+                document.getElementById("topUsingCardBody"+i).onclick = function () { setDetailViewModal(data[i].id);}
                 document.getElementById("topUsingTitle"+i).innerHTML = data[i].title;
                 document.getElementById("topUsingRate"+i).innerHTML = data[i].usingrate;
             }

--- a/assets/template/ItemsRecentlyCreate.html
+++ b/assets/template/ItemsRecentlyCreate.html
@@ -38,7 +38,7 @@
                                 </video>
                             {{end}}
                         </a>
-                        <div class="card-body" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
+                        <div class="card-body" id="recentCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
                             <h5 class="card-title mb-0" id="recentlyTitle{{$i}}">{{.Title}}</h5>
                             <span class="text-muted" id="recentlyCreateTime{{$i}}" style="font-size: 13px;">{{SplitTimeData .CreateTime}}</span><br>
                             <div class="row m-0 mb-2"style="align-items: center;">

--- a/assets/template/ItemsTopUsing.html
+++ b/assets/template/ItemsTopUsing.html
@@ -36,7 +36,7 @@
                             </video>
                         {{end}}
                         </a>
-                        <div class="card-body" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
+                        <div class="card-body" id="topUsingCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
                             <h5 class="card-title" id="topUsingTitle{{$i}}">{{.Title}}</h5>
                             <div class="row m-0 mb-2"style="align-items: center;">
                                 <i class="fas fa-download fa-xs" style="color:grey;"></i>


### PR DESCRIPTION
close: #1266 

card body 선택했을 때 onclick으로  detailview 호출되는 부분의 item id도 next/prev 버튼 누를 때마다 스위칭 해줬어야 했어요
그 부분이 누락돼서 수정했습니다