### PR TITLE
최초 안내페이지: init title, card 정렬 맞추기

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -194,6 +194,13 @@ body {
 	font-size: 17px;
 }
 
+.init-items {
+	display: flex;
+	margin-left: 5%;
+	margin-right: 5%;
+	justify-content: space-between;
+}
+
 .init-tags {
 	margin-left: 5%;
 	margin-right: 5%;
@@ -204,13 +211,30 @@ body {
 	color: #d9d9d9;
 }
 
+@media screen and (max-width: 375px) {
+	.init-title {
+		margin-left: 10%;
+		margin-right: 10%;
+	}
+	
+	.init-items {
+		margin-left: 10%;
+		margin-right: 10%;
+	}
+	
+	.init-tags {
+		margin-left: 10%;
+		margin-right: 10%;
+	}
+}
+
 
 /*------------------------------*/
 /*------------ card ------------*/
 /*------------------------------*/
 
 .card{
-    margin: 10px;
+	margin: 10px 0px;
     width: 18rem;
     border-radius: 0px;
     border: 1px;

--- a/assets/template/ItemsRecentlyCreate.html
+++ b/assets/template/ItemsRecentlyCreate.html
@@ -1,6 +1,8 @@
 {{define "itemsRecentlyCreate"}}
     {{$thumbnailwidth := .Adminsetting.ThumbnailImageWidth}}
     {{$thumbnailheight := .Adminsetting.ThumbnailImageHeight}}
+    <input type="hidden" id="thumbnailwidth" value="{{$thumbnailwidth}}">
+    <input type="hidden" id="thumbnailheight" value="{{$thumbnailheight}}">
     <h6 class="init-title">NEW {{$.RecentlyTotalItemNum}}
         <div class="slider-icon float-right">
             <span class="btn carousel-control-prev-icon" aria-hidden="true" onclick="recentlyClick('{{.RecentlyTotalItemNum}}', 'prev');" ></span>

--- a/assets/template/ItemsRecentlyCreate.html
+++ b/assets/template/ItemsRecentlyCreate.html
@@ -1,8 +1,6 @@
 {{define "itemsRecentlyCreate"}}
     {{$thumbnailwidth := .Adminsetting.ThumbnailImageWidth}}
     {{$thumbnailheight := .Adminsetting.ThumbnailImageHeight}}
-    <input type="hidden" id="thumbnailwidth" value="{{$thumbnailwidth}}">
-    <input type="hidden" id="thumbnailheight" value="{{$thumbnailheight}}">
     <h6 class="init-title">NEW {{$.RecentlyTotalItemNum}}
         <div class="slider-icon float-right">
             <span class="btn carousel-control-prev-icon" aria-hidden="true" onclick="recentlyClick('{{.RecentlyTotalItemNum}}', 'prev');" ></span>
@@ -10,47 +8,43 @@
             <span class="btn carousel-control-next-icon" aria-hidden="true" onclick="recentlyClick('{{.RecentlyTotalItemNum}}', 'next');" ></span>
         </div>
     </h6>
-    <div class="container-fluid">
-        <div class="row mx-auto mb-12">
-            {{range $i, $q := .RecentlyCreateItems}}
-                {{$itemtype := .ItemType}}
-                <div class="col-xl-3 col-lg-6 col-md-6 col-sm-12">
-                    <div class="card mx-auto" id="recentCard{{$i}}">
-                        <a class="card-image" href="#" title="image {{$i}}" class="thumb" id="recentlyImageForm{{$i}}">
-                            {{if eq $itemtype "hwp" "ies" "pdf" "ppt" "sound"}}
-                                <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="/assets/img/{{$itemtype}}thumbnail.svg">
-                            {{else if eq $itemtype "hdri" "texture" "lut" }}
-                                <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
-                            {{else if eq $itemtype "clip"}}
-                                <video class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" autoplay loop>
-                                    <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
-                                    <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
-                                    Your browser does not support the video tag.
-                                </video>
-                            {{else}}
-                                <video class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" controls poster="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
-                                    <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
-                                    <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
-                                    Your browser does not support the video tag.
-                                </video>
-                            {{end}}
-                        </a>
-                        <div class="card-body" id="recentCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
-                            <h5 class="card-title mb-0" id="recentlyTitle{{$i}}">{{.Title}}</h5>
-                            <span class="text-muted" id="recentlyCreateTime{{$i}}" style="font-size: 13px;">{{SplitTimeData .CreateTime}}</span><br>
-                            <div class="row m-0 mb-2"style="align-items: center;">
-                                <i class="fas fa-download fa-xs" style="color:grey;"></i>
-                                <p class="card-text">{{.UsingRate}}</p>
-                            </div>
-                            <div>
-                                {{range .Tags}}
-                                    <a href="/search?itemtype={{$itemtype}}&searchword=tag:{{.}}" class="tag badge badge-outline-darkmode">{{.}}</a>
-                                {{end}}
-                            </div>
-                        </div>
+    <div class="row init-items">
+        {{range $i, $q := .RecentlyCreateItems}}
+            {{$itemtype := .ItemType}}
+            <div class="card" id="recentCard{{$i}}">
+                <a class="card-image" href="#" title="image {{$i}}" class="thumb" id="recentlyImageForm{{$i}}">
+                    {{if eq $itemtype "hwp" "ies" "pdf" "ppt" "sound"}}
+                        <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="/assets/img/{{$itemtype}}thumbnail.svg">
+                    {{else if eq $itemtype "hdri" "texture" "lut" }}
+                        <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
+                    {{else if eq $itemtype "clip"}}
+                        <video class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" autoplay loop>
+                            <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
+                            <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
+                            Your browser does not support the video tag.
+                        </video>
+                    {{else}}
+                        <video class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" controls poster="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
+                            <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
+                            <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
+                            Your browser does not support the video tag.
+                        </video>
+                    {{end}}
+                </a>
+                <div class="card-body" id="recentCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
+                    <h5 class="card-title mb-0" id="recentlyTitle{{$i}}">{{.Title}}</h5>
+                    <span class="text-muted" id="recentlyCreateTime{{$i}}" style="font-size: 13px;">{{SplitTimeData .CreateTime}}</span><br>
+                    <div class="row m-0 mb-2"style="align-items: center;">
+                        <i class="fas fa-download fa-xs" style="color:grey;"></i>
+                        <p class="card-text">{{.UsingRate}}</p>
+                    </div>
+                    <div>
+                        {{range .Tags}}
+                            <a href="/search?itemtype={{$itemtype}}&searchword=tag:{{.}}" class="tag badge badge-outline-darkmode">{{.}}</a>
+                        {{end}}
                     </div>
                 </div>
-            {{end}}
-        </div>
+            </div>
+        {{end}}
     </div>
 {{end}}

--- a/assets/template/ItemsRecentlyTag.html
+++ b/assets/template/ItemsRecentlyTag.html
@@ -1,6 +1,6 @@
 {{define "itemsRecentlyTag"}}
 <h6 class="init-title">New Tags {{len $.RecentTags}}</h6>
-<div class="container init-tags">
+<div class="init-tags">
     {{range .RecentTags}}
         <a href="/search?searchword=tag:{{.}}" class="tag badge badge-outline-darkmode">{{.}}</a>
     {{end}}

--- a/assets/template/ItemsTopUsing.html
+++ b/assets/template/ItemsTopUsing.html
@@ -7,42 +7,37 @@
             <span class="slider-text" id="topUsingPage" value="1">1 / {{divCeil $.TopUsingTotalItemNum 4}}</span>
             <span class="btn carousel-control-next-icon" aria-hidden="true" onclick="topUsingClick('{{.TopUsingTotalItemNum}}', 'next');" ></span>
         </div>
-        <!-- </div> -->
     </h6>
-    <div class="container-fluid">
-        <div class="row mx-auto mb-12">
-            {{range $i, $q := .TopUsingItems}}
-                {{$itemtype := .ItemType}}
-                <div class="col-xl-3 col-lg-6 col-md-6 col-sm-12">
-                    <div class="card mx-auto" id="topUsingCard{{$i}}">
-                        <a class="card-image" href="#" title="image {{$i}}" id="topUsingImageForm{{$i}}">
-                        {{if eq .ItemType "hwp" "ies" "pdf" "ppt" "sound"}}
-                            <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="/assets/img/{{$itemtype}}thumbnail.svg">
-                        {{else if eq .ItemType "hdri" "lut" "texture" }}
-                            <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
-                        {{else}}
-                            <video class="card-img"width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" controls poster="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
-                                <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
-                                <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
-                                Your browser does not support the video tag.
-                            </video>
+    <div class="row init-items">
+        {{range $i, $q := .TopUsingItems}}
+            {{$itemtype := .ItemType}}
+            <div class="card" id="topUsingCard{{$i}}">
+                <a class="card-image" href="#" title="image {{$i}}" id="topUsingImageForm{{$i}}">
+                {{if eq .ItemType "hwp" "ies" "pdf" "ppt" "sound"}}
+                    <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="/assets/img/{{$itemtype}}thumbnail.svg">
+                {{else if eq .ItemType "hdri" "lut" "texture" }}
+                    <img class="card-img" width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" src="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
+                {{else}}
+                    <video class="card-img"width="{{$thumbnailwidth}}" height="{{$thumbnailheight}}" controls poster="{{if eq .Status "done" }}/mediadata?id={{.ID.Hex}}&type=png{{else}}/assets/img/noimage.svg{{end}}">
+                        <source src="/mediadata?id={{.ID.Hex}}&type=mp4" type="video/mp4">
+                        <source src="/mediadata?id={{.ID.Hex}}&type=ogg" type="video/ogg">
+                        Your browser does not support the video tag.
+                    </video>
+                {{end}}
+                </a>
+                <div class="card-body" id="topUsingCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
+                    <h5 class="card-title" id="topUsingTitle{{$i}}">{{.Title}}</h5>
+                    <div class="row m-0 mb-2"style="align-items: center;">
+                        <i class="fas fa-download fa-xs" style="color:grey;"></i>
+                        <p class="card-text" id="topUsingRate{{$i}}">{{.UsingRate}}</p>
+                    </div>
+                    <div>
+                        {{range .Tags}}
+                            <a href="/search?itemtype={{$itemtype}}&searchword=tag:{{.}}" class="tag badge badge-outline-darkmode">{{.}}</a>
                         {{end}}
-                        </a>
-                        <div class="card-body" id="topUsingCardBody{{$i}}" data-toggle="modal" data-target="#modal-detailview" onclick="setDetailViewModal('{{.ID.Hex}}')">
-                            <h5 class="card-title" id="topUsingTitle{{$i}}">{{.Title}}</h5>
-                            <div class="row m-0 mb-2"style="align-items: center;">
-                                <i class="fas fa-download fa-xs" style="color:grey;"></i>
-                                <p class="card-text" id="topUsingRate{{$i}}">{{.UsingRate}}</p>
-                            </div>
-                            <div>
-                                {{range .Tags}}
-                                    <a href="/search?itemtype={{$itemtype}}&searchword=tag:{{.}}" class="tag badge badge-outline-darkmode">{{.}}</a>
-                                {{end}}
-                            </div>
-                        </div>
                     </div>
                 </div>
-            {{end}}
-        </div>
+            </div>
+        {{end}}
     </div>
 {{end}}

--- a/assets/template/head.html
+++ b/assets/template/head.html
@@ -11,7 +11,6 @@
 <link rel="stylesheet" href="/assets/bootstrap-4/css/bootstrap.min.css">
 <link rel="stylesheet" href="/assets/css/default.css">
 <link rel="stylesheet" href="/assets/css/dropzone.css">
-<link rel="stylesheet" href="/assets/css/items.css">
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css">
 </head>
 {{end}}


### PR DESCRIPTION
close: #1286 

card 정렬을 bootstrap grid system 에서 flex box로 바꿔서 해결했어요!

## desktop
<img width="1538" alt="스크린샷 2020-09-07 오후 10 03 51" src="https://user-images.githubusercontent.com/46209590/92391875-5e50ef80-f158-11ea-9917-4b906bd67101.png">

## ipad
<img width="823" alt="스크린샷 2020-09-07 오후 10 03 40" src="https://user-images.githubusercontent.com/46209590/92391887-63ae3a00-f158-11ea-8644-a7c3ef45edd5.png">

## iphone
<img width="364" alt="스크린샷 2020-09-07 오후 10 20 42" src="https://user-images.githubusercontent.com/46209590/92391943-788acd80-f158-11ea-8c5c-0d32fce7def2.png">
