### PR TITLE
즐겨찾기: 최초 안내페이지에서 아이템 스위칭 될 때 불규칙적으로 즐겨찾기 아이템 못받아오는 버그 수정

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -434,7 +434,7 @@ function topUsingClick(totalItemNum, buttonState) {
         success: function(response) {
             favoriteAssetIds = response["favoriteAssetIds"];
         },
-        complete: function(response) {
+        complete: function() {
             // Top Using Item 정보 가져온 후 세팅
             $.ajax({
                 url: `/api/topusingitem?usingpage=${currentPageNum}`,

--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -285,9 +285,7 @@ function recentlyClick(totalItemNum, buttonState) {
         type: "get",
         dataType: "json",
         success: function(response) {
-            if (response["favoriteAssetIds"] != null) {
-                favoriteAssetIds = response["favoriteAssetIds"];
-            }
+            favoriteAssetIds = response["favoriteAssetIds"];
         },
         complete: function() {
             // Recent Item 정보 가져온 후 세팅


### PR DESCRIPTION
close: #1345
 
처음 구조는 아래와 같았습니다.

1. ajax로 현재 user의 즐겨찾기 아이템 리스트를 받아오는 코드 
2. ajax로 최근 등록된 item을 받아와 아이템들을 세팅하는 코드(즐겨찾기 itemids for문 돌면서 현재 아이템과 일치하는 게 있다면 아이템을 채워주는 기능 포함)

그런데 기존 코드가 ajax는 비동기식이라는 걸 간과한 것이였어서 1번 과정이 다 끝나기 전에 2번이 실행되는 경우에는 즐겨찾기 아이템 id임에도 아이콘이 채워지지 않는 경우가 발생했어요.

그래서 1번째 ajax 안에서 complete 시, 2번 ajax를 수행하도록 수정했습니다!