### PR TITLE
PPT: keynote업로드 안되는 버그 해결

### DIFF
--- a/http_ppt.go
+++ b/http_ppt.go
@@ -323,7 +323,7 @@ func uploadPptFile(w http.ResponseWriter, r *http.Request, objectID string) {
 			unix.Umask(umask)
 			mimeType := f.Header.Get("Content-Type")
 			switch mimeType {
-			case "application/octet-stream", "application/zip", "application/vnd.ms-powerpoint", "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+			case "application/octet-stream", "application/zip", "application/vnd.ms-powerpoint", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "application/x-iwork-keynote-sffkey":
 				ext := filepath.Ext(f.Filename)
 				if ext != ".key" && ext != ".zip" && ext != ".ppt" && ext != ".pptx" { // .ma .mb 외에는 허용하지 않는다.
 					http.Error(w, "허용하지 않는 파일 포맷입니다", http.StatusBadRequest)


### PR DESCRIPTION
close: #1364 
keynote에 해당하는 mimetype을 추가했어요!

<img width="626" alt="image" src="https://user-images.githubusercontent.com/40417084/101435168-32a7f600-394f-11eb-9a75-3be79480582a.png">
