### PR TITLE
Footage : addfootage시 premultiply 적용 여부 설정 부분 추가

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -64,6 +64,30 @@ body {
 	-webkit-appearance:none;
 }
 
+.custom-check-input {
+	display: none;
+}
+
+.custom-check-input + label {
+	background-color:  #1C1C1C;
+	border:1px solid #A7A59C;
+	color: #A7A59C;
+    border-radius: 3px;
+	width: 15px;
+	height: 15px;
+	position: relative;
+	top: 3px;
+	margin-right: 10px;
+	margin-bottom: 0px
+}
+
+.custom-check-input:checked + label:before {
+	content: "\2714";
+	position: absolute;
+	top: -5px;
+}
+
+
 .custom-select {
 	background-color:  rgb(41, 41, 41)!important;
 	color: #A7A59C;

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -4,10 +4,6 @@ body {
 	background-color: #2e2d2d;
 }
 
-video {
-	background-color: black;
-}
-
 .dropdown-divider {
 	border:1px solid rgb(55, 55, 52);
 }

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -4,6 +4,10 @@ body {
 	background-color: #2e2d2d;
 }
 
+video {
+	background-color: black;
+}
+
 .dropdown-divider {
 	border:1px solid rgb(55, 55, 52);
 }

--- a/assets/template/addfootage-item.html
+++ b/assets/template/addfootage-item.html
@@ -88,6 +88,18 @@
         <div class="row">
             <div class="col-sm">
                 <div class="form-group">
+                    <label class="text-muted">Premult</label>
+                    <div class="custom-check">
+                        <input type="checkbox" name="premult" class="custom-check-input" id="chbox">
+                        <label for="chbox"></label>
+                        <small class="custom-check-label text-muted"> 체크 시, 어셋 썸네일 비디오에 premult가 적용됩니다.</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm">
+                <div class="form-group">
                     <label class="text-muted">Attributes</label>
                     <div id="attributes">
                         <div class="row">

--- a/assets/template/addfootage-item.html
+++ b/assets/template/addfootage-item.html
@@ -88,11 +88,11 @@
         <div class="row">
             <div class="col-sm">
                 <div class="form-group">
-                    <label class="text-muted">Premult</label>
+                    <label class="text-muted">Premultiply</label>
                     <div class="custom-check">
                         <input type="checkbox" name="premult" class="custom-check-input" id="chbox">
                         <label for="chbox"></label>
-                        <small class="custom-check-label text-muted"> 체크 시, 어셋 썸네일 비디오에 premult가 적용됩니다.</small>
+                        <small class="custom-check-label text-muted"> 체크 시, 어셋 썸네일 비디오에 premultiply가 적용됩니다.</small>
                     </div>
                 </div>
             </div>

--- a/http_footage.go
+++ b/http_footage.go
@@ -116,9 +116,9 @@ func handleUploadFootageItem(w http.ResponseWriter, r *http.Request) {
 	item.Tags = tags
 	item.ItemType = "footage"
 	if r.FormValue("premult") == "" {
-		item.Premult = false
+		item.Premultiply = false
 	} else {
-		item.Premult = true
+		item.Premultiply = true
 	}
 	attr := make(map[string]string)
 	attrNum, err := strconv.Atoi(r.FormValue("attributesNum"))

--- a/http_footage.go
+++ b/http_footage.go
@@ -115,6 +115,11 @@ func handleUploadFootageItem(w http.ResponseWriter, r *http.Request) {
 	tags := Str2Tags(r.FormValue("tags"))
 	item.Tags = tags
 	item.ItemType = "footage"
+	if r.FormValue("premult") == "" {
+		item.Premult = false
+	} else {
+		item.Premult = true
+	}
 	attr := make(map[string]string)
 	attrNum, err := strconv.Atoi(r.FormValue("attributesNum"))
 	if err != nil {

--- a/process.go
+++ b/process.go
@@ -1472,7 +1472,7 @@ func genProxyToOggMedia(adminSetting Adminsetting, item Item) error {
 		),
 	}
 	if item.Premult {
-		args = append(args, "-vf premultiply=inplace=1")
+		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.
@@ -1580,7 +1580,7 @@ func genProxyToMovMedia(adminSetting Adminsetting, item Item) error {
 		),
 	}
 	if item.Premult {
-		args = append(args, "-vf premultiply=inplace=1")
+		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.
@@ -1686,7 +1686,7 @@ func genProxyToMp4Media(adminSetting Adminsetting, item Item) error {
 		),
 	}
 	if item.Premult {
-		args = append(args, "-vf premultiply=inplace=1")
+		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.

--- a/process.go
+++ b/process.go
@@ -1471,6 +1471,9 @@ func genProxyToOggMedia(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaHeight,
 		),
 	}
+	if item.Premult {
+		args = append(args, "-vf premultiply=inplace=1")
+	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.
 		args = append(args, "-an")
@@ -1576,6 +1579,9 @@ func genProxyToMovMedia(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaHeight,
 		),
 	}
+	if item.Premult {
+		args = append(args, "-vf premultiply=inplace=1")
+	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.
 		args = append(args, "-an")
@@ -1678,6 +1684,9 @@ func genProxyToMp4Media(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaWidth,
 			adminSetting.MediaHeight,
 		),
+	}
+	if item.Premult {
+		args = append(args, "-vf premultiply=inplace=1")
 	}
 	if adminSetting.AudioCodec == "nosound" {
 		// nosound라면 사운드를 넣지 않는 옵션을 추가한다.

--- a/process.go
+++ b/process.go
@@ -1471,7 +1471,7 @@ func genProxyToOggMedia(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaHeight,
 		),
 	}
-	if item.Premult {
+	if item.Premultiply {
 		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {
@@ -1579,7 +1579,7 @@ func genProxyToMovMedia(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaHeight,
 		),
 	}
-	if item.Premult {
+	if item.Premultiply {
 		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {
@@ -1685,7 +1685,7 @@ func genProxyToMp4Media(adminSetting Adminsetting, item Item) error {
 			adminSetting.MediaHeight,
 		),
 	}
-	if item.Premult {
+	if item.Premultiply {
 		args = append(args, []string{"-vf", "premultiply=inplace=1"}...)
 	}
 	if adminSetting.AudioCodec == "nosound" {

--- a/struct_item.go
+++ b/struct_item.go
@@ -37,7 +37,7 @@ type Item struct {
 	InColorspace  string `json:"incolorspace" bson:"incolorspace"`   // InColorspace
 	OutColorspace string `json:"outcolorspace" bson:"outcolorspace"` // OutColorspace
 	Fps           string `json:"fps" bson:"fps"`                     // fps값 ffmpeg 연산에 사용되는 값이기 때문에 문자열로 처리함.
-	Premult       bool   `json:"premult" bson:"premult"`             // proxy sequence to video 연산 과정에서 premult 적용 여부 체크
+	Premultiply   bool   `json:"premultiply" bson:"premultiply"`     // proxy sequence to video 연산 과정에서 Premultiply 적용 여부 체크
 
 	KindOfUSD string `json:"kindofusd" bson:"kindofusd"` // Kind Of USD
 }

--- a/struct_item.go
+++ b/struct_item.go
@@ -37,6 +37,7 @@ type Item struct {
 	InColorspace  string `json:"incolorspace" bson:"incolorspace"`   // InColorspace
 	OutColorspace string `json:"outcolorspace" bson:"outcolorspace"` // OutColorspace
 	Fps           string `json:"fps" bson:"fps"`                     // fps값 ffmpeg 연산에 사용되는 값이기 때문에 문자열로 처리함.
+	Premult       bool   `json:"premult" bson:"premult"`             // proxy sequence to video 연산 과정에서 premult 적용 여부 체크
 
 	KindOfUSD string `json:"kindofusd" bson:"kindofusd"` // Kind Of USD
 }


### PR DESCRIPTION
close: #1366

### 체크박스 추가
![image](https://user-images.githubusercontent.com/46209590/102333682-1b14e100-3fd1-11eb-82ad-cbacdd6540d9.png)
Footage proxy 시퀀스를 video로 변환하는 부분에 [premult](https://nanite.tistory.com/98) 적용할 수 있는 체크박스 추가했습니다!

### ~~Video 태그 스타일~~
~~그리고 alpha가 있는 썸네일 뒤에는 검정배경으로 채워주고 싶어서 video 태그는 검정색으로 되게 css 추가했어요~~
![png-nonebackground](https://user-images.githubusercontent.com/46209590/102333808-413a8100-3fd1-11eb-81fa-c72ce6acbb13.png)
![png-withbackground](https://user-images.githubusercontent.com/46209590/102333812-426bae00-3fd1-11eb-8e20-5c67866388ab.png)

