### PR TITLE
Process: 썸네일 처리 프로세스 실행 전에 LD_LIBRARY_PATH 환경변수 세팅해주는 부분 추가

### DIFF
--- a/process.go
+++ b/process.go
@@ -97,6 +97,33 @@ func processingItem(item Item) {
 		log.Println(err)
 		return
 	}
+	// LD_LIBRARY_PATH 환경변수를 세팅한다.
+	adminLdLibPath := adminSetting.LDLibraryPath
+	if adminLdLibPath != "" {
+		var ldLibPath string
+		adminLdLibPaths := strings.Split(adminLdLibPath, ":")
+		// 세팅할 path 중 $LD_LIBRARY_PATH가 있다면
+		// os에서 할당값을 받아와 세팅해준 후 slice에서 제거
+		for _, path := range adminLdLibPaths {
+			if path == "$LD_LIBRARY_PATH" {
+				envLdLibPath := strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":")
+				ldLibPath = strings.Join(envLdLibPath, ":")
+				for num := 0; num < len(adminLdLibPaths); num++ {
+					if adminLdLibPaths[num] == "$LD_LIBRARY_PATH" {
+						adminLdLibPaths = append(adminLdLibPaths[:num], adminLdLibPaths[num+1:]...)
+					}
+				}
+			}
+		}
+		if ldLibPath == "" {
+			ldLibPath = strings.Join(adminLdLibPaths, ":")
+		} else {
+			ldLibPath += ":" + strings.Join(adminLdLibPaths, ":")
+		}
+		if ldLibPath != "" {
+			os.Setenv("LD_LIBRARY_PATH", ldLibPath)
+		}
+	}
 	// ItemType별로 연산한다.
 	switch item.ItemType {
 	case "maya":

--- a/process.go
+++ b/process.go
@@ -100,29 +100,7 @@ func processingItem(item Item) {
 	// LD_LIBRARY_PATH 환경변수를 세팅한다.
 	adminLdLibPath := adminSetting.LDLibraryPath
 	if adminLdLibPath != "" {
-		var ldLibPath string
-		adminLdLibPaths := strings.Split(adminLdLibPath, ":")
-		// 세팅할 path 중 $LD_LIBRARY_PATH가 있다면
-		// os에서 할당값을 받아와 세팅해준 후 slice에서 제거
-		for _, path := range adminLdLibPaths {
-			if path == "$LD_LIBRARY_PATH" {
-				envLdLibPath := strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":")
-				ldLibPath = strings.Join(envLdLibPath, ":")
-				for num := 0; num < len(adminLdLibPaths); num++ {
-					if adminLdLibPaths[num] == "$LD_LIBRARY_PATH" {
-						adminLdLibPaths = append(adminLdLibPaths[:num], adminLdLibPaths[num+1:]...)
-					}
-				}
-			}
-		}
-		if ldLibPath == "" {
-			ldLibPath = strings.Join(adminLdLibPaths, ":")
-		} else {
-			ldLibPath += ":" + strings.Join(adminLdLibPaths, ":")
-		}
-		if ldLibPath != "" {
-			os.Setenv("LD_LIBRARY_PATH", ldLibPath)
-		}
+		os.Setenv("LD_LIBRARY_PATH", adminLdLibPath)
 	}
 	// ItemType별로 연산한다.
 	switch item.ItemType {


### PR DESCRIPTION
close: #1370

원래는 adminsetting 에서 `$LD_LIBRARY_PATH:/blar/blar`라고 써줬으면 웹서버 os에 `LD_LIBRARY_PATH`로 할당된 값을 가져와서 세팅해주는 식으로 코드를 짰었는데요.
이게 되면 `$HOME/blar/blar` 이런 것도 처리가 가능해야할 것 같은데 그렇진 않아서 그 부분은 삭제했어요.