### PR TITLE
Process: jobs 채널에 아이템 중복으로 쌓이는 버그 수정

### DIFF
--- a/dbapi.go
+++ b/dbapi.go
@@ -542,7 +542,7 @@ func SetStatusAndGetItem(item Item, status string) (Item, error) {
 	}
 	collection := client.Database(*flagDBName).Collection("items")
 	option := *options.FindOneAndUpdate().SetReturnDocument(options.After)
-	err = collection.FindOneAndUpdate(ctx, filter, update, &option).Err()
+	err = collection.FindOneAndUpdate(ctx, filter, update, &option).Decode(&result)
 	if err != nil {
 		return result, err
 	}

--- a/process.go
+++ b/process.go
@@ -345,7 +345,13 @@ func queueingItem(jobs chan<- Item) {
 			time.Sleep(time.Second * 10)
 			continue
 		}
-		jobs <- item
+		updatedItem, err := SetStatusAndGetItem(item, "queued for processing")
+		if err != nil {
+			log.Println(err)
+			time.Sleep(time.Second * 10)
+			continue
+		}
+		jobs <- updatedItem
 		// 10초후 다시 queueing 한다.
 		time.Sleep(time.Second * 10)
 	}


### PR DESCRIPTION
close: #1380 

- `SetStatusAndGetItem` dbapi 추가
- jobs 채널에 들어가면 item status가 `queued for processing`으로 변경되게 함