### PR TITLE
사용자 비밀번호 초기화 기능 추가

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -585,3 +585,30 @@ function clickBookmarkIcon(target, fillBool, itemid) {
         })
     }    
 }
+
+// initPasword 함수는 비밀번호 초기화 버튼을 눌렀을 때 실행되는 함수이다.
+function initPasword() {
+    let token = document.getElementById("token").value;
+    let checkboxes = document.querySelectorAll('*[name^="checkbox"]:checked');
+
+    for (i = 0; i < checkboxes.length; i++) {
+        let userID = checkboxes[i].value;
+        $.ajax({
+            url: "/api/initpassword",
+            headers: {
+                "Authorization": "Basic " + token
+            },
+            type: "post",
+            data: {
+                id: userID,
+            },
+            success: function() {
+                alert(userID+" 사용자의 패스워드가 초기화 되었습니다");
+                location.reload();
+            },
+            error: function() {
+                alert(userID+" 사용자의 패스워드를 초기화하는 데 실패하였습니다.")
+            }
+        })
+    }
+}

--- a/assets/template/adminsetting.html
+++ b/assets/template/adminsetting.html
@@ -244,6 +244,15 @@
                         </div>
                     </div>
                 </div>
+                <div class="row">
+                    <div class="col-sm">
+                        <div class="form-group">
+                            <label class="text-muted">Init Password</label>
+                            <input type="password" name="initpassword" class="form-control" placeholder="패스워드 초기값" value="{{.Adminsetting.InitPassword}}">
+                            <small class="form-text text-muted">사용자의 패스워드 초기화 값을 설정해주세요.</small>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="text-center pt-5">
                 <button type="submit" class="btn btn-outline-danger">UPDATE</button>

--- a/assets/template/navbar.html
+++ b/assets/template/navbar.html
@@ -47,6 +47,7 @@
                Admin
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <a class="dropdown-item" href="/users">Users</a>
                 <a class="dropdown-item" href="/adminsetting">Admin Setting</a>
                 <a class="dropdown-item" href="/cleanup-db">Clean Up DB</a>
             </div>

--- a/assets/template/users.html
+++ b/assets/template/users.html
@@ -1,0 +1,64 @@
+{{define "users"}}
+{{template "head"}}
+<body>
+    {{template "navbar" .}}
+    <input type="hidden" id="token" value="{{$.User.Token}}">
+    <div class="container pt-5 pb-5">
+        <div class="text-center mx-auto pt-5">
+            <h2 class="text-muted">Users</h2>
+        </div>
+        <div class="text-center pt-3 pb-5">
+            <span class="btn btn-outline-danger btn-sm" onclick="initPasword()">패스워드 초기화</span>
+        </div>
+        <div class="row pt-1 pb-1 text-muted text-center">
+            <div class="col-sm-2 col-md-2 col-lg-2">
+                index
+            </div>
+            <div class="col-sm-2 col-md-2 col-lg-2">
+                <input type="checkbox" class="form-check-input" id="toggle-checkbox" onclick="toggleItems();">
+            </div>
+            <div class="col-sm-4 col-md-4 col-lg-4">
+                ID
+            </div>
+            <div class="col-sm-4 col-md-4 col-lg-4">
+                Access Level
+            </div>
+        </div>
+        <div>
+            <hr class="my-1 p-0 m-0 divider">
+        </div>
+        <div class="text-muted text-center">
+            {{$index := 1}}
+            {{range .Users}}
+                <label style="width : 100%; margin-bottom : 0px">
+                    <div class="row py-1">
+                        <div class="col-sm-2 col-md-2 col-lg-2">
+                            <span class="text-center">{{$index}}</span>
+                        </div>
+                        <div class="col-sm-2 col-md-2 col-lg-2">
+                            <input type="checkbox" id="item{{$index}}" name="checkbox{{$index}}" class="form-check-input" value="{{.ID}}">
+                        </div>
+                        <div class="col-sm-4 col-md-4 col-lg-4">
+                            {{.ID}}
+                        </div>
+                        <div class="col-sm-4 col-md-4 col-lg-4">
+                            {{.AccessLevel}}
+                        </div>
+                    </div>
+                    <div>
+                        <hr class="my-1 p-0 m-0 divider">
+                    </div>
+                </label>
+            {{$index = add $index 1}}
+            {{end}}
+        </div>
+        <input type="hidden" id="usernum" name="usernum" value="{{$index}}">
+    </div>
+    {{template "footer"}}
+</body>
+<!--add javascript-->
+<script src="/assets/js/jquery-3.1.1.min.js"></script>
+<script src="/assets/bootstrap-4/js/bootstrap.min.js"></script>
+<script src="/assets/js/dotori.js"></script>
+</html>
+{{end}}

--- a/dbapi.go
+++ b/dbapi.go
@@ -410,6 +410,25 @@ func GetUser(client *mongo.Client, id string) (User, error) {
 	return u, nil
 }
 
+// GetAllUsers 함수는 DB에서 전체 사용자 정보를 가져오는 함수이다.
+func GetAllUsers(client *mongo.Client) ([]User, error) {
+	collection := client.Database(*flagDBName).Collection("users")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var results []User
+	opts := options.Find()
+	opts.SetSort(bson.M{"id": 1})
+	cursor, err := collection.Find(ctx, bson.D{}, opts)
+	if err != nil {
+		return results, err
+	}
+	err = cursor.All(ctx, &results)
+	if err != nil {
+		return results, err
+	}
+	return results, err
+}
+
 // SetAdminSetting 은 입력받은 어드민셋팅으로 업데이트한다.
 func SetAdminSetting(client *mongo.Client, a Adminsetting) error {
 	collection := client.Database(*flagDBName).Collection("setting.admin")

--- a/http.go
+++ b/http.go
@@ -333,6 +333,7 @@ func webserver() {
 	http.HandleFunc("/editlut-success", handleEditLutSuccess)
 
 	// Admin
+	http.HandleFunc("/users", handleUsers)
 	http.HandleFunc("/adminsetting", handleAdminSetting)
 	http.HandleFunc("/adminsetting-submit", handleAdminSettingSubmit)
 	http.HandleFunc("/adminsetting-success", handleAdminSettingSuccess)
@@ -371,6 +372,7 @@ func webserver() {
 	http.HandleFunc("/api/recentitem", handleAPIRecentItem)
 	http.HandleFunc("/api/topusingitem", handleAPITopUsingItem)
 	http.HandleFunc("/api/favoriteasset", handleAPIFavoriteAsset)
+	http.HandleFunc("/api/initpassword", handleAPIInitPassword)
 
 	// 웹서버 실행
 	if *flagCertFullchain != "" || *flagCertPrivkey != "" {

--- a/http_adminsetting.go
+++ b/http_adminsetting.go
@@ -138,6 +138,7 @@ func handleAdminSettingSubmit(w http.ResponseWriter, r *http.Request) {
 	a.VideoCodecMp4 = r.FormValue("videocodecmp4")
 	a.VideoCodecMov = r.FormValue("videocodecmov")
 	a.AudioCodec = r.FormValue("audiocodec")
+	a.InitPassword = r.FormValue("initpassword")
 	//mongoDB client 연결
 	client, err := mongo.NewClient(options.Client().ApplyURI(*flagMongoDBURI))
 	if err != nil {

--- a/http_users.go
+++ b/http_users.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+// handleUsers 함수는 Users 페이지를 띄워주는 함수이다.
+func handleUsers(w http.ResponseWriter, r *http.Request) {
+	token, err := GetTokenFromHeader(w, r)
+	if err != nil {
+		http.Redirect(w, r, "/signin", http.StatusSeeOther)
+		return
+	}
+	//mongoDB client 연결
+	client, err := mongo.NewClient(options.Client().ApplyURI(*flagMongoDBURI))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = client.Connect(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer client.Disconnect(ctx)
+	err = client.Ping(ctx, readpref.Primary())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Access level 체크
+	if token.AccessLevel != "admin" {
+		http.Redirect(w, r, "/invalidaccess", http.StatusSeeOther)
+		return
+	}
+
+	type recipe struct {
+		User         User
+		Token        Token
+		Adminsetting Adminsetting
+		Users        []User
+	}
+	rcp := recipe{}
+	rcp.User, err = GetUser(client, token.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rcp.Token = token
+	rcp.Adminsetting, err = GetAdminSetting(client)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rcp.Users, err = GetAllUsers(client)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	err = TEMPLATES.ExecuteTemplate(w, "users", rcp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/struct_adminsetting.go
+++ b/struct_adminsetting.go
@@ -33,6 +33,7 @@ type Adminsetting struct {
 	VideoCodecMp4           string `json:"videocodecmp4" bson:"videocodecmp4"`                     // 비디오 코덱
 	VideoCodecMov           string `json:"videocodecmov" bson:"videocodecmov"`                     // 비디오 코덱
 	AudioCodec              string `json:"audiocodec" bson:"audiocodec"`                           // 오디오 코덱
+	InitPassword            string `json:"initpassword" bson:"initpassword"`                       // 사용자가 패스워드를 잃어버렸을 때 초기화하는 패스워드
 }
 
 // CheckError 는 Adminsetting 자료구조에 값이 정확히 들어갔는지 확인하는 메소드이다.


### PR DESCRIPTION
- AdminSetting 자료구조에 InitPassword 추가
- AdminSetting 페이지에서 InitPassword 설정할 수 있도록 함
![dotori_adminsetting](https://user-images.githubusercontent.com/14924389/116044998-8c198300-a6ac-11eb-9b90-42ba5d8f3f5d.png)

- Users 페이지 추가
![dotori_users](https://user-images.githubusercontent.com/14924389/116045022-93409100-a6ac-11eb-8908-865ced103efe.png)

- 여러명의 사용자들을 선택한 후 비밀번호 초기화 버튼을 클릭하면 Admin setting에 설정된 비밀번호로 초기화 됨
![dotori_initpw](https://user-images.githubusercontent.com/14924389/116045039-96d41800-a6ac-11eb-8d89-ac5955c49e8f.png)

이 페이지에 사용자의 액세스 레벨을 수정하거나 사용자를 삭제하는 기능이 추가될 예정입니다!

close: #1401