### PR TITLE
Set Sponsor 엔진비주얼웨이브

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 #github: [lazypic]
-custom: ['http://www.rd101.co.kr','https://lazypic.org']
+custom: ['http://rd101.co.kr','http://www.enginevw.co.kr','https://lazypic.org']

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, RD101 & Lazypic,LLC.
+Copyright (c) 2019-2022, RD101 & eNgine visual wave Co.,Ltd. & Lazypic,LLC.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ VFX, 애니메이션, 게임, 사운드 등 콘텐츠 제작에 사용되는 에
 - 개발기간: 2019.9 ~ 現
 - 개발방법: 오픈소스 공동개발 프로젝트
 - 개발형태 : Web Application Server
-- 개발언어: Go, Javascript, HTML, CSS
-- 개발주체: [(주)로드원오원](http://rd101.co.kr) + [Lazypic,LLC.](https://lazypic.org)
+- 개발도구: Go, mongoDB, Javascript, HTML, CSS
+- 개발지원: [(주)로드원오원](http://rd101.co.kr), [(주)엔진비주얼웨이브](http://www.enginevw.co.kr), [Lazypic,LLC.](https://lazypic.org)
 - 권리자(발명자): [Contributors](https://github.com/RD101/dotori/graphs/contributors)
 - 테스트서버: https://dotori.lazypic.com
 - [다운로드](https://github.com/RD101/dotori/releases)

--- a/assets/template/footer.html
+++ b/assets/template/footer.html
@@ -4,7 +4,7 @@
                 © 2019-2022 by 
                 <a href="http://rd101.co.kr" class="text-muted">RD101</a> &
                 <a href="http://www.enginevw.co.kr" class="text-muted">eNgine visual wave Co.,Ltd.</a> &
-                <a href="https://lazypic.org" class="text-muted"> Lazypic, LLC</a>
+                <a href="https://lazypic.org" class="text-muted"> Lazypic,LLC.</a>
         </small>
 </div>
 {{end}}

--- a/assets/template/footer.html
+++ b/assets/template/footer.html
@@ -1,7 +1,10 @@
 {{define "footer"}}
 <div class="text-center text-muted pt-3">
         <small class="pb-2 pt-3">
-                © 2020 by <a href="https://rd101.co.kr" class="text-muted">RD101</a> & <a href="https://lazypic.org" class="text-muted">Lazypic, LLC</a>
+                © 2019-2022 by 
+                <a href="http://rd101.co.kr" class="text-muted">RD101</a> &
+                <a href="http://www.enginevw.co.kr" class="text-muted">eNgine visual wave Co.,Ltd.</a> &
+                <a href="https://lazypic.org" class="text-muted"> Lazypic, LLC</a>
         </small>
 </div>
 {{end}}

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,32 @@
 module github.com/rd101/dotori
 
-go 1.15
+go 1.17
 
 require (
-	github.com/golang-jwt/jwt v3.2.0+incompatible
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.0
-	github.com/kr/pretty v0.2.0 // indirect
+	github.com/golang-jwt/jwt v3.2.0+incompatible
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	go.mongodb.org/mongo-driver v1.5.1
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	gopkg.in/yaml.v2 v2.2.8
+)
+
+require (
+	github.com/aws/aws-sdk-go v1.34.28 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/text v0.3.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -53,9 +55,8 @@ github.com/klauspost/compress v1.9.5 h1:U+CaK85mrNNb4k8BNOfgJtJ/gr6kswUCFj6miSzV
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -109,7 +110,6 @@ golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
- 라이센스, 스폰서 (주)엔진비주얼웨이브 추가
- go mod 시 필요한 라이브러리 업데이트
- go 개발 버전, github action 버전을 1.7로 변경함.

Close: #1461 
