### PR TITLE
로그 페이지 수정. 정보를 좀더 볼 수 있도록 함.

### DIFF
--- a/assets/template/item-process.html
+++ b/assets/template/item-process.html
@@ -1,7 +1,7 @@
 {{define "item-process"}}
-{{template "head"}}
+{{template "head-bootstrap5"}}
 <body>
-    {{template "navbar" .}}
+    {{template "navbar-bootstrap5" .}}
     <div class="container pt-5 pb-5">
         <div class="my-auto pb-5">
             <h5 class="text-muted pb-3">{{.StorageTitle}}</h5>
@@ -37,7 +37,7 @@
                 id
             </div>
             <div class="col-sm-12 col-md-6 col-lg-4">
-                status
+                createtime
             </div>
         </div>       
         <div class="text-muted text-center">
@@ -59,7 +59,12 @@
                         <div class="col-sm-12 col-md-6 col-lg-3">
                             {{.ID.Hex}}
                         </div>
-                        <div class="col-sm-12 col-md-6 col-lg-4 my-auto">
+                        <div class="col-sm-12 col-md-6 col-lg-4">
+                            <span class="text-center">{{.CreateTime}}</span>
+                        </div>
+                    </div>
+                    <div class="row pt-1 pb-1">
+                        <div class="col-sm-12 col-md-12 col-lg-12 my-auto">
                             <div class="progress">
                                 {{if eq .Status "error"}}
                                     <div class="progress-bar progress-bar-striped bg-danger" role="progressbar" style="width: 100%" aria-valuenow="10" aria-valuemin="1" aria-valuemax="10">
@@ -73,6 +78,7 @@
                             </div>
                         </div>
                     </div>
+                    
                     <div>
                         <hr class="my-1 p-0 m-0 divider">
                     </div>
@@ -83,8 +89,6 @@
     {{template "footer"}}
 </body>
 <!--add javascript-->
-<script src="/assets/js/jquery-3.1.1.min.js"></script>
-<script src="/assets/bootstrap-4/js/bootstrap.min.js"></script>
-<script src="/assets/js/dropzone.js"></script>
+<script src="/assets/bootstrap-5.1.3-dist/js/bootstrap.min.js"></script>
 </html>
 {{end}}


### PR DESCRIPTION
- 생성시간 표기
- 로그가 표시되는 부분 영역 연장
- 부트스트랩5로 페이지 업데이트
- 불필요한 라이브러리 제거

Close: #1546 

<img width="1202" alt="update_process_page" src="https://user-images.githubusercontent.com/1149996/172044074-c39cc61f-2867-4799-8e76-6e16151d59de.png">

