### PR TITLE
아이템 정보 modal에서 copypath 버튼 제거.

### DIFF
--- a/assets/js/dotori.js
+++ b/assets/js/dotori.js
@@ -123,16 +123,13 @@ function setDetailViewModal(itemid) {
             let outputdatapath=response["outputdatapath"]
             let footerHtml = `
             <button type="button" class="btn btn-sm btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?id=${itemid}'">Download</button>
-            <button type="button" class="btn btn-sm btn-outline-darkmode" id="modal-detailview-copypath-button" onclick="copyPath('${outputdatapath}')">Copy Path</button>
             `
             let footerHtmlForAdmin=`
             <button type="button" class="btn btn-sm btn-outline-darkmode" id="modal-detailview-download-button" onclick="location.href='/download-item?id=${itemid}'">Download</button>
-            <button type="button" class="btn btn-sm btn-outline-darkmode" id="modal-detailview-copypath-button" onclick="copyPath('${outputdatapath}')">Copy Path</button>
             <button type="button" class="btn btn-sm btn-outline-danger" id="modal-detailview-download-button" onclick="location.href='/rename/${itemid}'">Rename</button>
             <button type="button" class="btn btn-sm btn-outline-danger" id="modal-detailview-delete-button" data-dismiss="modal" data-toggle="modal" data-target="#modal-rmitem">Delete</button>
             `
             if (document.getElementById("accesslevel").value == "admin") {
-                console.log("test")
                 document.getElementById("modal-rmitem-itemid").value = itemid;
                 document.getElementById("modal-detailview-footer").innerHTML = footerHtmlForAdmin       // admin 계정일 때만 delete 버튼이 보인다.
             } else {


### PR DESCRIPTION
- console에서 test 라고 찍히는 구문 제거
- bootstrap 모달에서 copypath 버튼을 제거함으로써 클립보드와 modal에 의한 에러자체를 없앰
    - 이미 아이템 밖에 copypath 버튼이 있다.
    - 상단 CopyPath 메뉴를 통해서 접근할 수 있다.
- 관련링크: https://www.google.com/search?q=javascript+copy+to+clipboard+not+working+modal&oq=javascript+copy+to+clipboard+not+working+modal&aqs=chrome..69i57.1426j0j7&sourceid=chrome&ie=UTF-8

Close: #1591