### PR TITLE
Admin 메뉴에 카테고리 활성화 기능 추가함.

### DIFF
--- a/assets/template/adminsetting.html
+++ b/assets/template/adminsetting.html
@@ -255,12 +255,22 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row mb-4">
+                    <div class="row mb-2">
                         <div class="col-sm">
                             <div class="from-group">
                                 <div class="form-check form-switch">
                                     <input class="form-check-input" type="checkbox" id="enablervlink" name="enablervlink" value="true" {{if .Adminsetting.EnableRVLink}}checked{{end}}>
                                     <label class="form-check-label text-muted" for="enablervlink">Enable Autodesk ShotGrid RV</label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-sm">
+                            <div class="from-group">
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" id="enablecategory" name="enablecategory" value="true" {{if .Adminsetting.EnableCategory}}checked{{end}}>
+                                    <label class="form-check-label text-muted" for="enablecategory">Enable Category</label>
                                 </div>
                             </div>
                         </div>

--- a/handle_adminsetting.go
+++ b/handle_adminsetting.go
@@ -140,6 +140,7 @@ func handleAdminSettingSubmit(w http.ResponseWriter, r *http.Request) {
 	a.AudioCodec = r.FormValue("audiocodec")
 	a.InitPassword = r.FormValue("initpassword")
 	a.EnableRVLink = str2bool(r.FormValue("enablervlink"))
+	a.EnableCategory = str2bool(r.FormValue("enablecategory"))
 	// 지원 포멧 셋팅
 	a.Maya = str2bool(r.FormValue("maya"))
 	a.Max = str2bool(r.FormValue("max"))

--- a/struct_adminsetting.go
+++ b/struct_adminsetting.go
@@ -35,6 +35,7 @@ type Adminsetting struct {
 	AudioCodec              string `json:"audiocodec" bson:"audiocodec"`                           // 오디오 코덱
 	InitPassword            string `json:"initpassword" bson:"initpassword"`                       // 사용자가 패스워드를 잃어버렸을 때 초기화하는 패스워드
 	EnableRVLink            bool   `json:"enablervlink" bson:"enablervlink"`                       // RVLink 활성화
+	EnableCategory          bool   `json:"enablercategory" bson:"enablecategory"`                  // 카테고리 활성화
 	// Support Add menu
 	Maya            bool `json:"maya" bson:"maya"`                       // Maya
 	Max             bool `json:"max" bson:"max"`                         // Max


### PR DESCRIPTION
기본적으로 에셋 라이브러리는 Tag 방식으로 풀 메니징이 가능하다.
분류, 그룹화를 위해서 카테고리를 사용한다면, 해당 기능을 활성화 할 수 있는 옵션이 Admin 메뉴에 필요하다.

Close: #1600 